### PR TITLE
feat: add transaction hash filter

### DIFF
--- a/src/App.res
+++ b/src/App.res
@@ -189,6 +189,7 @@ let make = (
           status: Some(0),
           type_: None,
           contractAddress: None,
+          hash: None,
           authorizationList: None,
         },
       ]),
@@ -247,6 +248,7 @@ let make = (
           status: None,
           type_: None,
           contractAddress: None,
+          hash: None,
           authorizationList: None,
         },
         {
@@ -256,6 +258,7 @@ let make = (
           status: None,
           type_: None,
           contractAddress: None,
+          hash: None,
           authorizationList: None,
         },
       ]),
@@ -315,6 +318,7 @@ let make = (
           status: None,
           type_: None,
           contractAddress: None,
+          hash: None,
           authorizationList: None,
         },
         {
@@ -324,6 +328,7 @@ let make = (
           status: None,
           type_: None,
           contractAddress: None,
+          hash: None,
           authorizationList: None,
         },
       ]),
@@ -434,6 +439,7 @@ let make = (
       status: None,
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     }
     setQuery(prev => {

--- a/src/BooleanLogicGenerator.res
+++ b/src/BooleanLogicGenerator.res
@@ -12,12 +12,13 @@ let isEmptyFilter = (filterState: filterState) => {
 
 // Helper function to check if a transaction filter is empty
 let isEmptyTransactionFilter = (filterState: QueryStructure.transactionSelection) => {
-  let {from_, to_, sighash, status, type_, contractAddress, authorizationList} = filterState
+  let {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList} = filterState
   let fromArray = from_->Option.getOr([])
   let toArray = to_->Option.getOr([])
   let sighashArray = sighash->Option.getOr([])
   let typeArray = type_->Option.getOr([])
   let contractAddressArray = contractAddress->Option.getOr([])
+  let hashArray = hash->Option.getOr([])
   let authArray = authorizationList->Option.getOr([])
 
   Array.length(fromArray) === 0 &&
@@ -26,6 +27,7 @@ let isEmptyTransactionFilter = (filterState: QueryStructure.transactionSelection
   Option.isNone(status) &&
   Array.length(typeArray) === 0 &&
   Array.length(contractAddressArray) === 0 &&
+  Array.length(hashArray) === 0 &&
   Array.length(authArray) === 0
 }
 
@@ -538,6 +540,7 @@ let generateMultiTransactionBooleanHierarchy = (
                   status: None,
                   type_: None,
                   contractAddress: None,
+                  hash: None,
                   authorizationList: None,
                 },
               ],

--- a/src/QueryResults.res
+++ b/src/QueryResults.res
@@ -172,6 +172,13 @@ let make = (
     | _ => None
     }
 
+    let hashJson = switch transactionFilter.hash {
+    | Some(hashes) if Array.length(hashes) > 0 =>
+      let hashesStr = Array.map(hashes, h => `"${h}"`)->Array.join(", ")
+      Some(`"hash": [${hashesStr}]`)
+    | _ => None
+    }
+
     let authorizationListJson = switch transactionFilter.authorizationList {
     | Some(authList) if Array.length(authList) > 0 =>
       let authListStr = Array.map(authList, auth => {
@@ -203,6 +210,7 @@ let make = (
         statusJson,
         typeJson,
         contractAddressJson,
+        hashJson,
         authorizationListJson,
       ]->Array.filterMap(x => x)
     let content = Array.join(allParts, ", ")

--- a/src/TransactionBooleanLogicGenerator.res
+++ b/src/TransactionBooleanLogicGenerator.res
@@ -1,12 +1,13 @@
 type transactionFilterState = QueryStructure.transactionSelection
 
 let generateEnglishDescription = (filterState: transactionFilterState) => {
-  let {from_, to_, sighash, status, type_, contractAddress, authorizationList} = filterState
+  let {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList} = filterState
   let fromArray = from_->Option.getOr([])
   let toArray = to_->Option.getOr([])
   let sighashArray = sighash->Option.getOr([])
   let typeArray = type_->Option.getOr([])
   let contractAddressArray = contractAddress->Option.getOr([])
+  let hashArray = hash->Option.getOr([])
   let authArray = authorizationList->Option.getOr([])
 
   let hasAnyFilter =
@@ -16,6 +17,7 @@ let generateEnglishDescription = (filterState: transactionFilterState) => {
     Option.isSome(status) ||
     Array.length(typeArray) > 0 ||
     Array.length(contractAddressArray) > 0 ||
+    Array.length(hashArray) > 0 ||
     Array.length(authArray) > 0
 
   if !hasAnyFilter {
@@ -99,6 +101,17 @@ let generateEnglishDescription = (filterState: transactionFilterState) => {
       parts->Array.push(contractCondition)->ignore
     }
 
+    // Hash condition
+    if Array.length(hashArray) > 0 {
+      let hashCondition = if Array.length(hashArray) === 1 {
+        `the transaction hash is ${Array.getUnsafe(hashArray, 0)}`
+      } else {
+        let hashList = Array.join(hashArray, " OR ")
+        `the transaction hash is ${hashList}`
+      }
+      parts->Array.push(hashCondition)->ignore
+    }
+
     // Authorization list condition
     if Array.length(authArray) > 0 {
       let authCondition = if Array.length(authArray) === 1 {
@@ -118,12 +131,13 @@ let generateEnglishDescription = (filterState: transactionFilterState) => {
 }
 
 let generateBooleanHierarchy = (filterState: transactionFilterState) => {
-  let {from_, to_, sighash, status, type_, contractAddress, authorizationList} = filterState
+  let {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList} = filterState
   let fromArray = from_->Option.getOr([])
   let toArray = to_->Option.getOr([])
   let sighashArray = sighash->Option.getOr([])
   let typeArray = type_->Option.getOr([])
   let contractAddressArray = contractAddress->Option.getOr([])
+  let hashArray = hash->Option.getOr([])
   let authArray = authorizationList->Option.getOr([])
 
   let hasAnyFilter =
@@ -133,6 +147,7 @@ let generateBooleanHierarchy = (filterState: transactionFilterState) => {
     Option.isSome(status) ||
     Array.length(typeArray) > 0 ||
     Array.length(contractAddressArray) > 0 ||
+    Array.length(hashArray) > 0 ||
     Array.length(authArray) > 0
 
   if !hasAnyFilter {
@@ -158,6 +173,9 @@ let generateBooleanHierarchy = (filterState: transactionFilterState) => {
     }
     if Array.length(contractAddressArray) > 0 {
       conditions->Array.push("contractAddress")->ignore
+    }
+    if Array.length(hashArray) > 0 {
+      conditions->Array.push("hash")->ignore
     }
     if Array.length(authArray) > 0 {
       conditions->Array.push("authorizationList")->ignore
@@ -329,6 +347,36 @@ let generateBooleanHierarchy = (filterState: transactionFilterState) => {
             "├── "
           }
           lines->Array.push(`${addrPrefix}${addr}`)->ignore
+        })
+      }
+      conditionIndex := conditionIndex.contents + 1
+    }
+
+    // Hash
+    if Array.length(hashArray) > 0 {
+      let isLast = conditionIndex.contents === Array.length(conditions) - 1
+      let prefix = hasMultipleConditions ? isLast ? "└── " : "├── " : ""
+
+      if Array.length(hashArray) === 1 {
+        lines->Array.push(`${prefix}hash = ${Array.getUnsafe(hashArray, 0)}`)->ignore
+      } else {
+        lines->Array.push(`${prefix}OR (hash)`)->ignore
+        Array.forEachWithIndex(hashArray, (h, i) => {
+          let isLastHash = i === Array.length(hashArray) - 1
+          let hashPrefix = if hasMultipleConditions {
+            if isLast {
+              isLastHash ? "    └── " : "    ├── "
+            } else if isLastHash {
+              "│   └── "
+            } else {
+              "│   ├── "
+            }
+          } else if isLastHash {
+            "└── "
+          } else {
+            "├── "
+          }
+          lines->Array.push(`${hashPrefix}${h}`)->ignore
         })
       }
       conditionIndex := conditionIndex.contents + 1

--- a/src/TransactionFilter.res
+++ b/src/TransactionFilter.res
@@ -17,6 +17,7 @@ let make = (
   let (newStatus, setNewStatus) = React.useState(() => "")
   let (newType, setNewType) = React.useState(() => "")
   let (newContractAddress, setNewContractAddress) = React.useState(() => "")
+  let (newHash, setNewHash) = React.useState(() => "")
 
   // Example filter states
   let eip7702Example: transactionFilterState = {
@@ -26,6 +27,7 @@ let make = (
     status: None,
     type_: Some([4]),
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
 
@@ -36,6 +38,7 @@ let make = (
     status: Some(0),
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
 
@@ -46,6 +49,7 @@ let make = (
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
 
@@ -56,6 +60,21 @@ let make = (
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
+    authorizationList: None,
+  }
+
+  let lookupByHashExample: transactionFilterState = {
+    from_: None,
+    to_: None,
+    sighash: None,
+    status: None,
+    type_: None,
+    contractAddress: None,
+    hash: Some([
+      "0x653a4532b6daf38b36e26794be5c27da1253811cfb1b422159232fd1aed68e40",
+      "0x45b366153d0b2decc91c1fef8b5dc9c4bb0a0d1d2d01daa4bbd26d06029b6ebc",
+    ]),
     authorizationList: None,
   }
 
@@ -73,6 +92,10 @@ let make = (
 
   let setApproveCallExample = () => {
     onFilterChange(approveCallExample)
+  }
+
+  let setLookupByHashExample = () => {
+    onFilterChange(lookupByHashExample)
   }
 
   let addFrom = () => {
@@ -187,6 +210,25 @@ let make = (
     })
   }
 
+  let addHash = () => {
+    if newHash !== "" && newHash->String.startsWith("0x") {
+      onFilterChange({
+        ...filterState,
+        hash: Some(Array.concat(filterState.hash->Option.getOr([]), [newHash])),
+      })
+      setNewHash(_ => "")
+    }
+  }
+
+  let removeHash = index => {
+    let currentArray = filterState.hash->Option.getOr([])
+    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+    onFilterChange({
+      ...filterState,
+      hash: Array.length(newArray) > 0 ? Some(newArray) : None,
+    })
+  }
+
   let _transactionSelectionToStruct = (): option<transactionSelection> => {
     Some(filterState)
   }
@@ -204,7 +246,7 @@ let make = (
   }
 
   let generateCodeBlock = () => {
-    let {from_, to_, sighash, status, type_, contractAddress} = filterState
+    let {from_, to_, sighash, status, type_, contractAddress, hash} = filterState
 
     let fromStr = switch from_ {
     | Some(fromArray) if Array.length(fromArray) > 0 => {
@@ -266,10 +308,27 @@ let make = (
     | _ => ""
     }
 
+    let hashStr = switch hash {
+    | Some(hashArray) if Array.length(hashArray) > 0 => {
+        let hashList =
+          hashArray
+          ->Array.map(h => `    "${h}"`)
+          ->Array.join(",\n")
+        `  "hash": [\n${hashList}\n  ]`
+      }
+    | _ => ""
+    }
+
     let parts =
-      [fromStr, toStr, sighashStr, statusStr, typeStr, contractAddressStr]->Array.filterMap(str =>
-        str !== "" ? Some(str) : None
-      )
+      [
+        fromStr,
+        toStr,
+        sighashStr,
+        statusStr,
+        typeStr,
+        contractAddressStr,
+        hashStr,
+      ]->Array.filterMap(str => str !== "" ? Some(str) : None)
     if Array.length(parts) > 0 {
       `{\n${Array.join(parts, ",\n")}\n}`
     } else {
@@ -283,7 +342,8 @@ let make = (
     Array.length(filterState.sighash->Option.getOr([])) > 0 ||
     Option.isSome(filterState.status) ||
     Array.length(filterState.type_->Option.getOr([])) > 0 ||
-    Array.length(filterState.contractAddress->Option.getOr([])) > 0
+    Array.length(filterState.contractAddress->Option.getOr([])) > 0 ||
+    Array.length(filterState.hash->Option.getOr([])) > 0
 
   <div
     className="relative bg-white rounded-xl border border-slate-200 shadow-sm transition-all w-full">
@@ -354,6 +414,11 @@ let make = (
               onClick={_ => setApproveCallExample()}
               className="px-2.5 py-1 bg-blue-600 text-white text-xs font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
               {"Approve EOA Calls"->React.string}
+            </button>
+            <button
+              onClick={_ => setLookupByHashExample()}
+              className="px-2.5 py-1 bg-amber-600 text-white text-xs font-medium rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500">
+              {"Lookup by Hash"->React.string}
             </button>
           </div>
 
@@ -606,6 +671,51 @@ let make = (
                   <button
                     onClick={_ => removeContractAddress(index)}
                     className="text-red-600 hover:text-red-800 text-sm">
+                    {"Remove"->React.string}
+                  </button>
+                </div>
+              )->React.array}
+            </div>
+          </div>
+
+          // Transaction Hashes
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              {"Transaction Hashes"->React.string}
+            </label>
+            <div className="flex space-x-2 mb-3">
+              <input
+                type_="text"
+                value={newHash}
+                onChange={e => {
+                  let target = ReactEvent.Form.target(e)
+                  setNewHash(_ => target["value"])
+                }}
+                placeholder="0x..."
+                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+              <button
+                onClick={_ => addHash()}
+                disabled={String.length(newHash) == 0 || !(newHash->String.startsWith("0x"))}
+                className="px-4 py-2 bg-amber-600 text-white text-sm font-medium rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 disabled:opacity-50 disabled:cursor-not-allowed">
+                {(
+                  Array.length(filterState.hash->Option.getOr([])) > 0
+                    ? "Add (via OR) Hash"
+                    : "Add Hash"
+                )->React.string}
+              </button>
+            </div>
+            <div className="space-y-2">
+              {Array.mapWithIndex(filterState.hash->Option.getOr([]), (h, index) =>
+                <div
+                  key={Int.toString(index)}
+                  className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md">
+                  <span className="text-sm font-mono text-gray-800 truncate">
+                    {h->React.string}
+                  </span>
+                  <button
+                    onClick={_ => removeHash(index)}
+                    className="text-red-600 hover:text-red-800 text-sm ml-2 shrink-0">
                     {"Remove"->React.string}
                   </button>
                 </div>

--- a/src/UrlEncoder.res
+++ b/src/UrlEncoder.res
@@ -226,6 +226,10 @@ let serializeUrlState = (state: urlState): string => {
                     | Some(addresses) => Js.Json.array(addresses->Array.map(Js.Json.string))
                     | None => Js.Json.null
                     }
+                    let hashJson = switch transaction.hash {
+                    | Some(hashes) => Js.Json.array(hashes->Array.map(Js.Json.string))
+                    | None => Js.Json.null
+                    }
                     let authorizationListJson = switch transaction.authorizationList {
                     | Some(authorizations) =>
                       Js.Json.array(
@@ -259,6 +263,7 @@ let serializeUrlState = (state: urlState): string => {
                         ("status", statusJson),
                         ("type_", typeJson),
                         ("contractAddress", contractAddressJson),
+                        ("hash", hashJson),
                         ("authorizationList", authorizationListJson),
                       ]),
                     )
@@ -597,6 +602,19 @@ let deserializeUrlState = (jsonString: string): option<urlState> => {
                         }
                       | None => None
                       }
+                      let hash = switch Js.Dict.get(transaction, "hash") {
+                      | Some(value) =>
+                        switch Js.Json.decodeNull(value) {
+                        | Some(_) => None
+                        | None =>
+                          switch Js.Json.decodeArray(value) {
+                          | Some(hashes) =>
+                            Some(hashes->Array.map(Js.Json.decodeString)->Array.filterMap(x => x))
+                          | None => None
+                          }
+                        }
+                      | None => None
+                      }
                       let authorizationList = switch Js.Dict.get(transaction, "authorizationList") {
                       | Some(value) =>
                         switch Js.Json.decodeNull(value) {
@@ -653,7 +671,7 @@ let deserializeUrlState = (jsonString: string): option<urlState> => {
                         }
                       | None => None
                       }
-                      {from_, to_, sighash, status, type_, contractAddress, authorizationList}
+                      {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList}
                     })
                   Some(decodedTransactions)
                 }

--- a/src/query-builder/QueryStructure.res
+++ b/src/query-builder/QueryStructure.res
@@ -22,6 +22,7 @@ type transactionSelection = {
   status: option<int>,
   type_: option<array<int>>,
   contractAddress: option<array<string>>,
+  hash: option<array<string>>,
   authorizationList: option<array<authorizationSelection>>,
 }
 

--- a/tests/BooleanLogicGenerator_MultiFilter_test.res
+++ b/tests/BooleanLogicGenerator_MultiFilter_test.res
@@ -25,6 +25,7 @@ test("generateMultiTransactionFilterDescription - single empty filter", () => {
       status: None,
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
   ])
@@ -41,6 +42,7 @@ test("generateMultiTransactionFilterDescription - single filter with from", () =
       status: None,
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
   ])
@@ -57,6 +59,7 @@ test("generateMultiTransactionFilterDescription - two filters with OR logic", ()
       status: None,
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
     {
@@ -66,6 +69,7 @@ test("generateMultiTransactionFilterDescription - two filters with OR logic", ()
       status: None,
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
   ])
@@ -86,6 +90,7 @@ test("generateMultiTransactionFilterDescription - complex ERC20 scenario", () =>
       status: Some(1),
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
     // ERC20 Approval
@@ -96,6 +101,7 @@ test("generateMultiTransactionFilterDescription - complex ERC20 scenario", () =>
       status: Some(1),
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
   ])
@@ -127,6 +133,7 @@ test("generateMultiTransactionBooleanHierarchy - single empty filter", () => {
       status: None,
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
   ])
@@ -143,6 +150,7 @@ test("generateMultiTransactionBooleanHierarchy - single non-empty filter", () =>
       status: None,
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
   ])
@@ -159,6 +167,7 @@ test("generateMultiTransactionBooleanHierarchy - two simple filters", () => {
       status: None,
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
     {
@@ -168,6 +177,7 @@ test("generateMultiTransactionBooleanHierarchy - two simple filters", () => {
       status: None,
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
   ])
@@ -186,6 +196,7 @@ test("generateMultiTransactionBooleanHierarchy - DEX multi-router scenario", () 
       status: Some(1),
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
     // Uniswap V3 Router
@@ -196,6 +207,7 @@ test("generateMultiTransactionBooleanHierarchy - DEX multi-router scenario", () 
       status: Some(1),
       type_: None,
       contractAddress: None,
+      hash: None,
       authorizationList: None,
     },
   ])

--- a/tests/transaction/TransactionBooleanLogicGenerator_test.res
+++ b/tests/transaction/TransactionBooleanLogicGenerator_test.res
@@ -10,6 +10,7 @@ test("generateEnglishDescription - empty transaction filter", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -24,6 +25,7 @@ test("generateEnglishDescription - single from address", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -38,6 +40,7 @@ test("generateEnglishDescription - multiple from addresses", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -52,6 +55,7 @@ test("generateEnglishDescription - single to address", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -66,6 +70,7 @@ test("generateEnglishDescription - multiple to addresses", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -80,6 +85,7 @@ test("generateEnglishDescription - single sighash", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -94,6 +100,7 @@ test("generateEnglishDescription - multiple sighashes", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -111,6 +118,7 @@ test("generateEnglishDescription - successful status", () => {
     status: Some(1),
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -125,6 +133,7 @@ test("generateEnglishDescription - failed status", () => {
     status: Some(0),
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -139,6 +148,7 @@ test("generateEnglishDescription - single type", () => {
     status: None,
     type_: Some([2]),
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -153,6 +163,7 @@ test("generateEnglishDescription - multiple types", () => {
     status: None,
     type_: Some([0, 2]),
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -167,6 +178,7 @@ test("generateEnglishDescription - single contract address", () => {
     status: None,
     type_: None,
     contractAddress: Some(["0xA0b86a33E6441c8C06DD2F1ea9D25E4A7BB9A74e"]),
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -184,6 +196,7 @@ test("generateEnglishDescription - complex transaction filter", () => {
     status: Some(1),
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateEnglishDescription(state)
@@ -201,6 +214,7 @@ test("generateBooleanHierarchy - empty transaction filter", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateBooleanHierarchy(state)
@@ -215,6 +229,7 @@ test("generateBooleanHierarchy - single from address", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateBooleanHierarchy(state)
@@ -229,6 +244,7 @@ test("generateBooleanHierarchy - multiple from addresses", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateBooleanHierarchy(state)
@@ -244,6 +260,7 @@ test("generateBooleanHierarchy - from and to addresses", () => {
     status: None,
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateBooleanHierarchy(state)
@@ -259,6 +276,7 @@ test("generateBooleanHierarchy - complex transaction with multiple conditions", 
     status: Some(1),
     type_: Some([2]),
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateBooleanHierarchy(state)
@@ -274,6 +292,7 @@ test("generateBooleanHierarchy - ERC20 transfer transaction", () => {
     status: Some(1),
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateBooleanHierarchy(state)
@@ -289,6 +308,7 @@ test("generateBooleanHierarchy - DEX swap transaction", () => {
     status: Some(1),
     type_: None,
     contractAddress: None,
+    hash: None,
     authorizationList: None,
   }
   let result = generateBooleanHierarchy(state)


### PR DESCRIPTION
## Summary
- Adds a `hash` filter to the transaction selection so queries can target specific transaction hashes.
- Fixes shareable builder URLs that include `transactions: [{ "hash": [...] }]`. The encoder previously dropped that field on round-trip; now it preserves it, so URLs like the gnosis lookup example load with the hashes populated.
- Adds a "Lookup by Hash" example in the transaction filter UI.

## Test plan
- [x] `npm run res:build` (ReScript build clean)
- [x] `npm test` (all 38 existing tests still pass after the new field is wired through)
- [ ] Open the example URL from the issue and confirm the two transaction hashes are populated and the query returns both transactions when executed
- [ ] Add a hash via the new UI input, copy the generated cURL, and confirm it produces the same response shape as the manual cURL in the issue