### PR TITLE
feat: add Solana query builder mode

### DIFF
--- a/src/Main.res
+++ b/src/Main.res
@@ -1,10 +1,35 @@
 %%raw("import './tailwind.css'")
 
+type ecosystem = Evm | Solana
+
+@val external windowLocation: 'a = "window"
+@get external locationOf: 'a => 'b = "location"
+@get external hashOf: 'a => string = "hash"
+@send external setHash: ('a, string) => unit = "replace"
+
+let getInitialEcosystem = (): ecosystem => {
+  let getHash: unit => string = %raw(`() => (typeof window !== 'undefined' ? window.location.hash : '')`)
+  let h = getHash()
+  if String.includes(h, "solana") {
+    Solana
+  } else {
+    Evm
+  }
+}
+
+let setHashFor = (e: ecosystem) => {
+  let setH: string => unit = %raw(`(s) => { if (typeof window !== 'undefined') window.location.hash = s }`)
+  switch e {
+  | Solana => setH("solana")
+  | Evm => setH("")
+  }
+}
+
 module AppWrapper = {
   @react.component
   let make = () => {
-    // Token state management at the top level
     let (bearerToken, setBearerToken) = React.useState(() => AuthToken.getToken())
+    let (ecosystem, setEcosystem) = React.useState(getInitialEcosystem)
 
     let handleTokenUpdate = (token: string) => {
       if AuthToken.saveToken(token) {
@@ -18,14 +43,47 @@ module AppWrapper = {
       }
     }
 
+    let switchEcosystem = (e: ecosystem) => {
+      setEcosystem(_ => e)
+      setHashFor(e)
+    }
+
+    let title = switch ecosystem {
+    | Evm => "HyperSync Query Builder"
+    | Solana => "HyperSync Query Builder · Solana"
+    }
+
     <div className="min-h-screen bg-slate-50 flex flex-col">
       <header className="bg-white/80 backdrop-blur border-b border-slate-200 sticky top-0 z-10">
         <div className="px-6 lg:px-4">
           <div className="flex items-center justify-between h-14">
-            <div className="flex items-center">
+            <div className="flex items-center space-x-4">
               <h1 className="text-lg font-semibold tracking-tight text-slate-900">
-                {"HyperSync Query Builder"->React.string}
+                {title->React.string}
               </h1>
+              <div
+                className="inline-flex items-center rounded-lg border border-slate-200 bg-slate-50 p-0.5">
+                <button
+                  onClick={_ => switchEcosystem(Evm)}
+                  className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${ecosystem ===
+                      Evm
+                      ? "bg-white text-slate-900 shadow-sm"
+                      : "text-slate-600 hover:text-slate-900"}`}>
+                  {"EVM"->React.string}
+                </button>
+                <button
+                  onClick={_ => switchEcosystem(Solana)}
+                  className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${ecosystem ===
+                      Solana
+                      ? "bg-white text-slate-900 shadow-sm"
+                      : "text-slate-600 hover:text-slate-900"}`}>
+                  {"Solana"->React.string}
+                  <span
+                    className="ml-1.5 inline-flex items-center px-1.5 py-0 rounded text-[10px] font-semibold bg-amber-100 text-amber-800">
+                    {"BETA"->React.string}
+                  </span>
+                </button>
+              </div>
             </div>
             <div className="flex items-center space-x-3">
               <TokenSettings
@@ -37,11 +95,9 @@ module AppWrapper = {
                 href="https://docs.envio.dev/docs/HyperSync/overview"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center px-3 py-1.5 bg-white hover:bg-slate-50 text-slate-700 hover:text-slate-900 text-xs font-medium rounded-lg transition-colors border border-slate-200"
-              >
+                className="inline-flex items-center px-3 py-1.5 bg-white hover:bg-slate-50 text-slate-700 hover:text-slate-900 text-xs font-medium rounded-lg transition-colors border border-slate-200">
                 <svg
-                  className="w-3 h-3 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"
-                >
+                  className="w-3 h-3 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path
                     strokeLinecap="round"
                     strokeLinejoin="round"
@@ -55,11 +111,9 @@ module AppWrapper = {
                 href="https://envio.dev"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center px-3 py-1.5 bg-white hover:bg-slate-50 text-slate-700 hover:text-slate-900 text-xs font-medium rounded-lg transition-colors border border-slate-200"
-              >
+                className="inline-flex items-center px-3 py-1.5 bg-white hover:bg-slate-50 text-slate-700 hover:text-slate-900 text-xs font-medium rounded-lg transition-colors border border-slate-200">
                 <svg
-                  className="w-3 h-3 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"
-                >
+                  className="w-3 h-3 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path
                     strokeLinecap="round"
                     strokeLinejoin="round"
@@ -73,7 +127,10 @@ module AppWrapper = {
           </div>
         </div>
       </header>
-      <App bearerToken onTokenSubmit={handleTokenUpdate} />
+      {switch ecosystem {
+      | Evm => <App bearerToken onTokenSubmit={handleTokenUpdate} />
+      | Solana => <SolanaApp bearerToken onTokenSubmit={handleTokenUpdate} />
+      }}
       <footer className="bg-white border-t border-slate-200 mt-auto">
         <div className="px-6 lg:px-8 py-3">
           <div className="flex items-center justify-center text-xs text-slate-500">

--- a/src/SolanaApp.res
+++ b/src/SolanaApp.res
@@ -1,0 +1,612 @@
+open SolanaQueryStructure
+
+// Common Solana Programs
+let tokenProgramId = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+let token2022ProgramId = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+let systemProgramId = "11111111111111111111111111111111"
+let computeBudgetProgramId = "ComputeBudget111111111111111111111111111111"
+
+@react.component
+let make = (
+  ~bearerToken: option<string>,
+  ~onTokenSubmit: string => unit,
+) => {
+  let defaultQuery = (): query => {
+    fromSlot: 0,
+    toSlot: None,
+    instructions: None,
+    transactions: None,
+    logs: None,
+    includeAllBlocks: None,
+    fields: emptyFieldSelection,
+    maxNumBlocks: Some(10),
+    maxNumTransactions: Some(10),
+    maxNumInstructions: Some(50),
+    maxNumLogs: Some(50),
+  }
+
+  let (query, setQuery) = React.useState(() => defaultQuery())
+  let (expandedFilterKey, setExpandedFilterKey) = React.useState(() => None)
+  let (executeSignal, setExecuteSignal) = React.useState(() => 0)
+  let (currentHead, setCurrentHead) = React.useState(() => None)
+
+  // Fetch current head on mount so users can pick a sensible from_slot
+  React.useEffect0(() => {
+    let load = async () => {
+      try {
+        open Fetch
+        let response = await fetchSimple("https://solana-near-head-test.hypersync.xyz/height")
+        let text = await response->Response.text
+        switch Int.fromString(String.trim(text)) {
+        | Some(n) => setCurrentHead(_ => Some(n))
+        | None => ()
+        }
+      } catch {
+      | _ => ()
+      }
+    }
+    load()->ignore
+    None
+  })
+
+  let toggleFilter = key =>
+    setExpandedFilterKey(prev =>
+      switch prev {
+      | Some(p) => p === key ? None : Some(key)
+      | None => Some(key)
+      }
+    )
+
+  let resetBuilder = () => {
+    setExpandedFilterKey(_ => None)
+    setQuery(_ => defaultQuery())
+  }
+
+  // Filter management
+  let addInstructionFilter = () => {
+    let newIndex = query.instructions->Option.getOr([])->Array.length
+    setQuery(prev => {
+      ...prev,
+      instructions: Some(
+        Array.concat(prev.instructions->Option.getOr([]), [emptyInstructionSelection]),
+      ),
+    })
+    setExpandedFilterKey(_ => Some(`instruction-${Int.toString(newIndex)}`))
+  }
+
+  let updateInstructionFilter = (index, newFilter) =>
+    setQuery(prev => {
+      let cur = prev.instructions->Option.getOr([])
+      let next = Array.mapWithIndex(cur, (f, i) => i === index ? newFilter : f)
+      {...prev, instructions: Some(next)}
+    })
+
+  let removeInstructionFilter = index => {
+    setQuery(prev => {
+      let cur = prev.instructions->Option.getOr([])
+      let next = Belt.Array.keepWithIndex(cur, (_, i) => i !== index)
+      {...prev, instructions: Array.length(next) > 0 ? Some(next) : None}
+    })
+    let key = `instruction-${Int.toString(index)}`
+    setExpandedFilterKey(prev => prev === Some(key) ? None : prev)
+  }
+
+  let addTransactionFilter = () => {
+    let newIndex = query.transactions->Option.getOr([])->Array.length
+    setQuery(prev => {
+      ...prev,
+      transactions: Some(
+        Array.concat(prev.transactions->Option.getOr([]), [emptyTransactionSelection]),
+      ),
+    })
+    setExpandedFilterKey(_ => Some(`transaction-${Int.toString(newIndex)}`))
+  }
+
+  let updateTransactionFilter = (index, newFilter) =>
+    setQuery(prev => {
+      let cur = prev.transactions->Option.getOr([])
+      let next = Array.mapWithIndex(cur, (f, i) => i === index ? newFilter : f)
+      {...prev, transactions: Some(next)}
+    })
+
+  let removeTransactionFilter = index => {
+    setQuery(prev => {
+      let cur = prev.transactions->Option.getOr([])
+      let next = Belt.Array.keepWithIndex(cur, (_, i) => i !== index)
+      {...prev, transactions: Array.length(next) > 0 ? Some(next) : None}
+    })
+    let key = `transaction-${Int.toString(index)}`
+    setExpandedFilterKey(prev => prev === Some(key) ? None : prev)
+  }
+
+  let addLogFilter = () => {
+    let newIndex = query.logs->Option.getOr([])->Array.length
+    setQuery(prev => {
+      ...prev,
+      logs: Some(Array.concat(prev.logs->Option.getOr([]), [emptyLogSelection])),
+    })
+    setExpandedFilterKey(_ => Some(`log-${Int.toString(newIndex)}`))
+  }
+
+  let updateLogFilter = (index, newFilter) =>
+    setQuery(prev => {
+      let cur = prev.logs->Option.getOr([])
+      let next = Array.mapWithIndex(cur, (f, i) => i === index ? newFilter : f)
+      {...prev, logs: Some(next)}
+    })
+
+  let removeLogFilter = index => {
+    setQuery(prev => {
+      let cur = prev.logs->Option.getOr([])
+      let next = Belt.Array.keepWithIndex(cur, (_, i) => i !== index)
+      {...prev, logs: Array.length(next) > 0 ? Some(next) : None}
+    })
+    let key = `log-${Int.toString(index)}`
+    setExpandedFilterKey(prev => prev === Some(key) ? None : prev)
+  }
+
+  let updateFieldSelection = newFields => setQuery(prev => {...prev, fields: newFields})
+
+  // Quick start presets
+  let applyPresetSplTokenTransfers = () => {
+    let from = switch currentHead {
+    | Some(h) => h - 5
+    | None => 0
+    }
+    setQuery(_ => {
+      ...defaultQuery(),
+      fromSlot: from,
+      toSlot: Some(from + 5),
+      instructions: Some([
+        {
+          ...emptyInstructionSelection,
+          programId: Some([tokenProgramId]),
+          d1: Some(["0x03"]),
+          includeTransaction: true,
+        },
+      ]),
+      fields: {
+        ...emptyFieldSelection,
+        block: [Slot, Blockhash, BlockTime],
+        transaction: [Slot, TransactionIndex, Signatures, FeePayer, Success, Fee],
+        instruction: [Slot, TransactionIndex, ProgramId, Data, A0, A1, A2, D1],
+      },
+      maxNumBlocks: Some(5),
+      maxNumTransactions: Some(50),
+      maxNumInstructions: Some(100),
+    })
+    setExpandedFilterKey(_ => Some("instruction-0"))
+  }
+
+  let applyPresetSystemTransfers = () => {
+    let from = switch currentHead {
+    | Some(h) => h - 5
+    | None => 0
+    }
+    setQuery(_ => {
+      ...defaultQuery(),
+      fromSlot: from,
+      toSlot: Some(from + 5),
+      instructions: Some([
+        {
+          ...emptyInstructionSelection,
+          programId: Some([systemProgramId]),
+          d4: Some(["0x02000000"]),
+          includeTransaction: true,
+        },
+      ]),
+      fields: {
+        ...emptyFieldSelection,
+        block: [Slot, Blockhash, BlockTime],
+        transaction: [Slot, TransactionIndex, Signatures, FeePayer, Success],
+        instruction: [Slot, TransactionIndex, ProgramId, Data, A0, A1, D4],
+      },
+      maxNumBlocks: Some(5),
+      maxNumTransactions: Some(50),
+      maxNumInstructions: Some(100),
+    })
+    setExpandedFilterKey(_ => Some("instruction-0"))
+  }
+
+  // include_all_blocks pulls every block in the slot range AND auto-attaches
+  // balances/token_balances per-tx, so even a few slots can produce many MB.
+  // Keep the range tight by default.
+  let applyPresetAllBlocks = () => {
+    let from = switch currentHead {
+    | Some(h) => h - 2
+    | None => 0
+    }
+    setQuery(_ => {
+      ...defaultQuery(),
+      fromSlot: from,
+      toSlot: Some(from + 2),
+      includeAllBlocks: Some(true),
+      fields: {
+        ...emptyFieldSelection,
+        block: [Slot, Blockhash, ParentSlot, BlockTime, BlockHeight],
+      },
+      maxNumBlocks: Some(2),
+    })
+  }
+
+  let totalFilters =
+    Array.length(query.instructions->Option.getOr([])) +
+    Array.length(query.transactions->Option.getOr([])) +
+    Array.length(query.logs->Option.getOr([]))
+
+  <>
+    {!AuthToken.isValidToken(bearerToken)
+      ? <TokenPrompt onTokenSubmit={onTokenSubmit} />
+      : React.null}
+    <main className="flex-1 overflow-hidden bg-slate-50">
+      // Experimental notice banner
+      <div className="bg-amber-50 border-b border-amber-200 px-6 py-3">
+        <div className="max-w-6xl mx-auto flex items-start gap-3">
+          <div className="shrink-0 mt-0.5">
+            <svg
+              className="w-5 h-5 text-amber-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+          </div>
+          <div className="flex-1 text-sm text-amber-900">
+            <p className="font-semibold mb-1">
+              {"Solana support is experimental"->React.string}
+            </p>
+            <p className="mb-1">
+              {"This is a preview release. The schema, endpoints, and behavior may change before the official launch. We will be expanding the historical slot range over time as the integration matures."->React.string}
+            </p>
+            <p>
+              {"Have questions or feedback? Reach out on "->React.string}
+              <a
+                href="https://discord.com/invite/envio"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-amber-900 underline hover:text-amber-700">
+                {"Discord"->React.string}
+              </a>
+              {"."->React.string}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="h-full flex flex-col lg:flex-row">
+        // Left Column - Builder
+        <div className="w-full lg:w-1/2 overflow-y-auto">
+          <div className="p-6 lg:p-4 lg:pr-2">
+            <div className="mb-6 flex items-center justify-between">
+              <div>
+                <h2 className="text-2xl font-bold text-slate-900 mb-1">
+                  {"Create Your Solana Query"->React.string}
+                </h2>
+                <p className="text-sm text-slate-600">
+                  {"Build and test HyperSync Solana queries with a visual interface"->React.string}
+                </p>
+              </div>
+              <button
+                onClick={_ => resetBuilder()}
+                className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-slate-600 hover:text-slate-900 bg-slate-100 hover:bg-slate-200 rounded-lg border border-slate-200 transition-colors">
+                {"Reset"->React.string}
+              </button>
+            </div>
+
+            <div className="space-y-6">
+              // Section 1: Configuration
+              <div className="bg-white rounded-xl p-6 border border-slate-200 shadow-sm">
+                <div className="mb-4">
+                  <h3 className="text-lg font-semibold text-slate-900">
+                    {"Network & Slot Range"->React.string}
+                  </h3>
+                  <p className="text-sm text-slate-600">
+                    {"Solana mainnet via the near-head endpoint"->React.string}
+                  </p>
+                </div>
+
+                <div className="mb-4 px-3 py-2 rounded-md bg-blue-50 border border-blue-200">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <span className="text-sm font-medium text-blue-900">
+                        {"Solana Mainnet (near head)"->React.string}
+                      </span>
+                      <div className="text-xs text-blue-700 font-mono">
+                        {"solana-near-head-test.hypersync.xyz"->React.string}
+                      </div>
+                    </div>
+                    {switch currentHead {
+                    | Some(h) =>
+                      <span className="text-xs text-blue-700">
+                        {`current head: slot ${Int.toString(h)}`->React.string}
+                      </span>
+                    | None => React.null
+                    }}
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <label className="block text-xs font-medium text-slate-700 mb-1">
+                      {"From Slot"->React.string}
+                    </label>
+                    <input
+                      type_="number"
+                      value={Int.toString(query.fromSlot)}
+                      onChange={e => {
+                        let target = ReactEvent.Form.target(e)
+                        let v = Int.fromString(target["value"])->Option.getOr(0)
+                        setQuery(prev => {...prev, fromSlot: v})
+                      }}
+                      className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-slate-500"
+                      placeholder="0"
+                    />
+                    {switch currentHead {
+                    | Some(h) =>
+                      <button
+                        onClick={_ => setQuery(prev => {...prev, fromSlot: h - 100})}
+                        className="mt-1 text-xs text-blue-600 hover:text-blue-800">
+                        {`Use head - 100 (${Int.toString(h - 100)})`->React.string}
+                      </button>
+                    | None => React.null
+                    }}
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-slate-700 mb-1">
+                      {"To Slot (Optional)"->React.string}
+                    </label>
+                    <input
+                      type_="number"
+                      value={switch query.toSlot {
+                      | Some(s) => Int.toString(s)
+                      | None => ""
+                      }}
+                      onChange={e => {
+                        let target = ReactEvent.Form.target(e)
+                        let value = target["value"]
+                        setQuery(prev => {
+                          ...prev,
+                          toSlot: value === "" ? None : Int.fromString(value),
+                        })
+                      }}
+                      className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-slate-500"
+                      placeholder="Latest slot"
+                    />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+                  {[
+                    ("max_num_blocks", query.maxNumBlocks, n => setQuery(prev => {...prev, maxNumBlocks: n})),
+                    ("max_num_transactions", query.maxNumTransactions, n => setQuery(prev => {...prev, maxNumTransactions: n})),
+                    ("max_num_instructions", query.maxNumInstructions, n => setQuery(prev => {...prev, maxNumInstructions: n})),
+                    ("max_num_logs", query.maxNumLogs, n => setQuery(prev => {...prev, maxNumLogs: n})),
+                  ]
+                  ->Array.map(((label, value, onSet)) =>
+                    <div key={label}>
+                      <label className="block text-xs font-medium text-slate-700 mb-1">
+                        {label->React.string}
+                      </label>
+                      <input
+                        type_="number"
+                        value={switch value {
+                        | Some(v) => Int.toString(v)
+                        | None => ""
+                        }}
+                        onChange={e => {
+                          let target = ReactEvent.Form.target(e)
+                          let v = target["value"]
+                          onSet(v === "" ? None : Int.fromString(v))
+                        }}
+                        className="w-full px-2 py-1.5 border border-slate-300 rounded-lg text-xs focus:outline-none focus:ring-2 focus:ring-slate-500"
+                        placeholder="none"
+                      />
+                    </div>
+                  )
+                  ->React.array}
+                </div>
+
+                <div>
+                  <label className="inline-flex items-center text-xs text-slate-700 cursor-pointer">
+                    <input
+                      type_="checkbox"
+                      checked={query.includeAllBlocks->Option.getOr(false)}
+                      onChange={e => {
+                        let target = ReactEvent.Form.target(e)
+                        setQuery(prev => {
+                          ...prev,
+                          includeAllBlocks: target["checked"] ? Some(true) : None,
+                        })
+                      }}
+                      className="mr-2"
+                    />
+                    {"include_all_blocks (return every block in range)"->React.string}
+                  </label>
+                </div>
+
+                // Quick Start
+                <div className="mt-6">
+                  <div className="mb-3">
+                    <h4 className="text-sm font-medium text-slate-900">
+                      {"Quick start"->React.string}
+                    </h4>
+                    <p className="text-xs text-slate-600">
+                      {"Start from a popular Solana template"->React.string}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      onClick={_ => applyPresetSplTokenTransfers()}
+                      className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
+                      {"SPL Token Transfers"->React.string}
+                    </button>
+                    <button
+                      onClick={_ => applyPresetSystemTransfers()}
+                      className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
+                      {"System Program SOL Transfers"->React.string}
+                    </button>
+                    <button
+                      onClick={_ => applyPresetAllBlocks()}
+                      className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
+                      {"All Blocks"->React.string}
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              // Section 2: Filters
+              <div className="bg-white rounded-xl p-6 border border-slate-200 shadow-sm">
+                <div className="flex items-center mb-4">
+                  <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-slate-900">
+                      {"Add Filters"->React.string}
+                    </h3>
+                    <p className="text-sm text-slate-600">
+                      {"Define what data you want: "->React.string}
+                      <span className="font-medium"> {"instructions"->React.string} </span>
+                      {", "->React.string}
+                      <span className="font-medium"> {"transactions"->React.string} </span>
+                      {", "->React.string}
+                      <span className="font-medium"> {"logs"->React.string} </span>
+                    </p>
+                  </div>
+                  {totalFilters > 0
+                    ? <span
+                        className="ml-auto inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700">
+                        {`${Int.toString(totalFilters)} filter${totalFilters === 1
+                            ? ""
+                            : "s"}`->React.string}
+                      </span>
+                    : React.null}
+                </div>
+
+                <div className="mb-6">
+                  <div className="flex flex-wrap gap-3">
+                    <button
+                      onClick={_ => addInstructionFilter()}
+                      className="inline-flex items-center px-4 py-2 bg-slate-900 text-white text-sm font-medium rounded-lg hover:bg-slate-950 transition-colors">
+                      {"+ Instruction Filter"->React.string}
+                    </button>
+                    <button
+                      onClick={_ => addTransactionFilter()}
+                      className="inline-flex items-center px-4 py-2 bg-slate-900 text-white text-sm font-medium rounded-lg hover:bg-slate-950 transition-colors">
+                      {"+ Transaction Filter"->React.string}
+                    </button>
+                    <button
+                      onClick={_ => addLogFilter()}
+                      className="inline-flex items-center px-4 py-2 bg-slate-900 text-white text-sm font-medium rounded-lg hover:bg-slate-950 transition-colors">
+                      {"+ Log Filter"->React.string}
+                    </button>
+                  </div>
+                </div>
+
+                {totalFilters > 0
+                  ? <div className="grid gap-4">
+                      {query.instructions
+                      ->Option.getOr([])
+                      ->Array.mapWithIndex((f, i) =>
+                        <SolanaInstructionFilter
+                          key={`instruction-${Int.toString(i)}`}
+                          filterState={f}
+                          onFilterChange={updateInstructionFilter(i, _)}
+                          onRemove={() => removeInstructionFilter(i)}
+                          filterIndex={i}
+                          isExpanded={expandedFilterKey === Some(`instruction-${Int.toString(i)}`)}
+                          onToggleExpand={() => toggleFilter(`instruction-${Int.toString(i)}`)}
+                        />
+                      )
+                      ->React.array}
+                      {query.transactions
+                      ->Option.getOr([])
+                      ->Array.mapWithIndex((f, i) =>
+                        <SolanaTransactionFilter
+                          key={`transaction-${Int.toString(i)}`}
+                          filterState={f}
+                          onFilterChange={updateTransactionFilter(i, _)}
+                          onRemove={() => removeTransactionFilter(i)}
+                          filterIndex={i}
+                          isExpanded={expandedFilterKey === Some(`transaction-${Int.toString(i)}`)}
+                          onToggleExpand={() => toggleFilter(`transaction-${Int.toString(i)}`)}
+                        />
+                      )
+                      ->React.array}
+                      {query.logs
+                      ->Option.getOr([])
+                      ->Array.mapWithIndex((f, i) =>
+                        <SolanaLogFilter
+                          key={`log-${Int.toString(i)}`}
+                          filterState={f}
+                          onFilterChange={updateLogFilter(i, _)}
+                          onRemove={() => removeLogFilter(i)}
+                          filterIndex={i}
+                          isExpanded={expandedFilterKey === Some(`log-${Int.toString(i)}`)}
+                          onToggleExpand={() => toggleFilter(`log-${Int.toString(i)}`)}
+                        />
+                      )
+                      ->React.array}
+                    </div>
+                  : <div
+                      className="text-center py-8 border-2 border-dashed border-slate-300 rounded-lg">
+                      <h4 className="text-sm font-medium text-slate-600 mb-1">
+                        {"No filters added yet"->React.string}
+                      </h4>
+                      <p className="text-xs text-slate-500">
+                        {"Click a button above to add your first filter, or use include_all_blocks to query every block in the slot range."->React.string}
+                      </p>
+                    </div>}
+              </div>
+
+              // Section 3: Field Selection
+              <div className="bg-white rounded-xl p-6 border border-slate-200 shadow-sm">
+                <div className="flex items-center mb-4">
+                  <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-slate-900">
+                      {"Select Fields"->React.string}
+                    </h3>
+                    <p className="text-sm text-slate-600">
+                      {"Choose which fields each table should return. Empty = no rows."->React.string}
+                    </p>
+                  </div>
+                </div>
+                <SolanaFieldSelector
+                  fieldSelection={query.fields} onFieldSelectionChange={updateFieldSelection}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        // Right Column - Results
+        <div className="w-full lg:w-1/2 overflow-y-auto">
+          <div className="p-6 lg:p-4 lg:pl-2">
+            <div className="mb-6 flex items-center justify-between">
+              <div>
+                <h2 className="text-2xl font-bold text-slate-900 mb-2">
+                  {"Query Results"->React.string}
+                </h2>
+                <p className="text-slate-600">
+                  {"View your generated query, execute it, and see the results."->React.string}
+                </p>
+              </div>
+              <div className="flex items-center">
+                <button
+                  onClick={_ => setExecuteSignal(prev => prev + 1)}
+                  className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-white bg-slate-700 hover:bg-slate-800 rounded-lg border border-slate-700 transition-colors">
+                  {"Execute Query"->React.string}
+                </button>
+              </div>
+            </div>
+            <SolanaQueryResults
+              query={query} executeSignal={executeSignal} bearerToken={bearerToken}
+            />
+          </div>
+        </div>
+      </div>
+    </main>
+  </>
+}

--- a/src/SolanaFieldSelector.res
+++ b/src/SolanaFieldSelector.res
@@ -1,0 +1,205 @@
+open SolanaQueryStructure
+
+let blockOptions: array<TagSelector.selectOption<blockField>> =
+  allBlockFields->Array.map(f => {
+    TagSelector.value: f,
+    label: snakeToTitle(blockFieldToSnake(f)),
+  })
+
+let transactionOptions: array<TagSelector.selectOption<transactionField>> =
+  allTransactionFields->Array.map(f => {
+    TagSelector.value: f,
+    label: snakeToTitle(transactionFieldToSnake(f)),
+  })
+
+let instructionOptions: array<TagSelector.selectOption<instructionField>> =
+  allInstructionFields->Array.map(f => {
+    TagSelector.value: f,
+    label: snakeToTitle(instructionFieldToSnake(f)),
+  })
+
+let logOptions: array<TagSelector.selectOption<logField>> =
+  allLogFields->Array.map(f => {
+    TagSelector.value: f,
+    label: snakeToTitle(logFieldToSnake(f)),
+  })
+
+let balanceOptions: array<TagSelector.selectOption<balanceField>> =
+  allBalanceFields->Array.map(f => {
+    TagSelector.value: f,
+    label: snakeToTitle(balanceFieldToSnake(f)),
+  })
+
+let tokenBalanceOptions: array<TagSelector.selectOption<tokenBalanceField>> =
+  allTokenBalanceFields->Array.map(f => {
+    TagSelector.value: f,
+    label: snakeToTitle(tokenBalanceFieldToSnake(f)),
+  })
+
+let rewardOptions: array<TagSelector.selectOption<rewardField>> =
+  allRewardFields->Array.map(f => {
+    TagSelector.value: f,
+    label: snakeToTitle(rewardFieldToSnake(f)),
+  })
+
+let renderSection = (
+  ~title: string,
+  ~total: int,
+  ~selectedCount: int,
+  ~onSelectAll: unit => unit,
+  ~onClear: unit => unit,
+  ~child: React.element,
+) => {
+  let allSelected = selectedCount == total
+  let noneSelected = selectedCount == 0
+  <div className="border border-gray-200 rounded-lg p-4">
+    <div className="mb-3">
+      <h4 className="font-medium text-gray-900"> {title->React.string} </h4>
+      <div className="mt-2 flex items-center gap-3">
+        {allSelected
+          ? React.null
+          : <button
+              onClick={_ => onSelectAll()}
+              className="text-xs text-blue-600 hover:text-blue-700">
+              {"All"->React.string}
+            </button>}
+        {noneSelected
+          ? React.null
+          : <button
+              onClick={_ => onClear()} className="text-xs text-red-600 hover:text-red-700">
+              {"Clear"->React.string}
+            </button>}
+      </div>
+    </div>
+    {child}
+    <div className="mt-3 pt-3 border-t border-gray-100">
+      <div className="text-xs text-gray-500">
+        {`${Int.toString(selectedCount)} selected`->React.string}
+      </div>
+    </div>
+  </div>
+}
+
+@react.component
+let make = (
+  ~fieldSelection: fieldSelection,
+  ~onFieldSelectionChange: fieldSelection => unit,
+) => {
+  let updateBlock = v => onFieldSelectionChange({...fieldSelection, block: v})
+  let updateTransaction = v => onFieldSelectionChange({...fieldSelection, transaction: v})
+  let updateInstruction = v => onFieldSelectionChange({...fieldSelection, instruction: v})
+  let updateLog = v => onFieldSelectionChange({...fieldSelection, log: v})
+  let updateBalance = v => onFieldSelectionChange({...fieldSelection, balance: v})
+  let updateTokenBalance = v => onFieldSelectionChange({...fieldSelection, tokenBalance: v})
+  let updateReward = v => onFieldSelectionChange({...fieldSelection, reward: v})
+
+  <div className="bg-white rounded-lg p-2 mb-2">
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+      {renderSection(
+        ~title="Block Fields",
+        ~total=Array.length(blockOptions),
+        ~selectedCount=Array.length(fieldSelection.block),
+        ~onSelectAll=() => updateBlock(allBlockFields),
+        ~onClear=() => updateBlock([]),
+        ~child=<TagSelector
+          title=""
+          placeholder="Add field..."
+          options={blockOptions}
+          selectedValues={fieldSelection.block}
+          onSelectionChange={updateBlock}
+          showInput={false}
+        />,
+      )}
+      {renderSection(
+        ~title="Transaction Fields",
+        ~total=Array.length(transactionOptions),
+        ~selectedCount=Array.length(fieldSelection.transaction),
+        ~onSelectAll=() => updateTransaction(allTransactionFields),
+        ~onClear=() => updateTransaction([]),
+        ~child=<TagSelector
+          title=""
+          placeholder="Add field..."
+          options={transactionOptions}
+          selectedValues={fieldSelection.transaction}
+          onSelectionChange={updateTransaction}
+          showInput={false}
+        />,
+      )}
+      {renderSection(
+        ~title="Instruction Fields",
+        ~total=Array.length(instructionOptions),
+        ~selectedCount=Array.length(fieldSelection.instruction),
+        ~onSelectAll=() => updateInstruction(allInstructionFields),
+        ~onClear=() => updateInstruction([]),
+        ~child=<TagSelector
+          title=""
+          placeholder="Add field..."
+          options={instructionOptions}
+          selectedValues={fieldSelection.instruction}
+          onSelectionChange={updateInstruction}
+          showInput={false}
+        />,
+      )}
+      {renderSection(
+        ~title="Log Fields",
+        ~total=Array.length(logOptions),
+        ~selectedCount=Array.length(fieldSelection.log),
+        ~onSelectAll=() => updateLog(allLogFields),
+        ~onClear=() => updateLog([]),
+        ~child=<TagSelector
+          title=""
+          placeholder="Add field..."
+          options={logOptions}
+          selectedValues={fieldSelection.log}
+          onSelectionChange={updateLog}
+          showInput={false}
+        />,
+      )}
+      {renderSection(
+        ~title="Balance Fields",
+        ~total=Array.length(balanceOptions),
+        ~selectedCount=Array.length(fieldSelection.balance),
+        ~onSelectAll=() => updateBalance(allBalanceFields),
+        ~onClear=() => updateBalance([]),
+        ~child=<TagSelector
+          title=""
+          placeholder="Add field..."
+          options={balanceOptions}
+          selectedValues={fieldSelection.balance}
+          onSelectionChange={updateBalance}
+          showInput={false}
+        />,
+      )}
+      {renderSection(
+        ~title="Token Balance Fields",
+        ~total=Array.length(tokenBalanceOptions),
+        ~selectedCount=Array.length(fieldSelection.tokenBalance),
+        ~onSelectAll=() => updateTokenBalance(allTokenBalanceFields),
+        ~onClear=() => updateTokenBalance([]),
+        ~child=<TagSelector
+          title=""
+          placeholder="Add field..."
+          options={tokenBalanceOptions}
+          selectedValues={fieldSelection.tokenBalance}
+          onSelectionChange={updateTokenBalance}
+          showInput={false}
+        />,
+      )}
+      {renderSection(
+        ~title="Reward Fields",
+        ~total=Array.length(rewardOptions),
+        ~selectedCount=Array.length(fieldSelection.reward),
+        ~onSelectAll=() => updateReward(allRewardFields),
+        ~onClear=() => updateReward([]),
+        ~child=<TagSelector
+          title=""
+          placeholder="Add field..."
+          options={rewardOptions}
+          selectedValues={fieldSelection.reward}
+          onSelectionChange={updateReward}
+          showInput={false}
+        />,
+      )}
+    </div>
+  </div>
+}

--- a/src/SolanaInstructionFilter.res
+++ b/src/SolanaInstructionFilter.res
@@ -1,0 +1,477 @@
+open SolanaQueryStructure
+
+type filterState = SolanaQueryStructure.instructionSelection
+
+let labelClass = "block text-xs font-medium text-slate-700 mb-1"
+let inputClass = "flex-1 border border-slate-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-colors"
+let addBtnClass = "px-3 py-2 bg-slate-700 text-white text-xs font-medium rounded-lg hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 disabled:opacity-50 transition-colors"
+let chipClass = "flex items-center justify-between bg-slate-50 px-3 py-1.5 rounded-lg border border-slate-100"
+
+let renderListEditor = (
+  ~label: string,
+  ~placeholder: string,
+  ~values: array<string>,
+  ~onAdd: string => unit,
+  ~onRemove: int => unit,
+  ~draft: string,
+  ~setDraft: (string => string) => unit,
+  ~validate: string => bool,
+) => {
+  <div className="mb-4">
+    <label className={labelClass}> {label->React.string} </label>
+    <div className="flex space-x-2 mb-2">
+      <input
+        type_="text"
+        value={draft}
+        onChange={e => {
+          let target = ReactEvent.Form.target(e)
+          setDraft(_ => target["value"])
+        }}
+        onKeyDown={e =>
+          if ReactEvent.Keyboard.key(e) === "Enter" {
+            ReactEvent.Synthetic.preventDefault(e)
+            if validate(draft) {
+              onAdd(draft)
+            }
+          }}
+        placeholder={placeholder}
+        className={inputClass}
+      />
+      <button
+        onClick={_ => onAdd(draft)}
+        disabled={String.length(draft) === 0 || !validate(draft)}
+        className={addBtnClass}>
+        {(Array.length(values) > 0 ? "Add (OR)" : "Add")->React.string}
+      </button>
+    </div>
+    {Array.length(values) > 0
+      ? <div className="space-y-1">
+          {values
+          ->Array.mapWithIndex((v, i) =>
+            <div key={Int.toString(i)} className={chipClass}>
+              <span className="text-xs font-mono text-slate-800 truncate"> {v->React.string} </span>
+              <button
+                onClick={_ => onRemove(i)}
+                className="ml-2 text-red-600 hover:text-red-800 text-xs font-medium transition-colors">
+                {"Remove"->React.string}
+              </button>
+            </div>
+          )
+          ->React.array}
+        </div>
+      : React.null}
+  </div>
+}
+
+let isHexBytes = (s: string, byteLen: int): bool => {
+  let hex = if String.startsWith(s, "0x") || String.startsWith(s, "0X") {
+    String.substring(s, ~start=2)
+  } else {
+    s
+  }
+  let len = String.length(hex)
+  let expected = byteLen * 2
+  if len !== expected {
+    false
+  } else {
+    let re = RegExp.fromString("^[0-9a-fA-F]+$")
+    RegExp.test(re, hex)
+  }
+}
+
+let isBase58Pubkey = (s: string): bool => {
+  let len = String.length(s)
+  if len < 32 || len > 44 {
+    false
+  } else {
+    let re = RegExp.fromString("^[1-9A-HJ-NP-Za-km-z]+$")
+    RegExp.test(re, s)
+  }
+}
+
+@react.component
+let make = (
+  ~filterState: filterState,
+  ~onFilterChange: filterState => unit,
+  ~onRemove: unit => unit,
+  ~filterIndex: int,
+  ~isExpanded: bool,
+  ~onToggleExpand: unit => unit,
+) => {
+  let (newProgramId, setNewProgramId) = React.useState(() => "")
+  let (newD1, setNewD1) = React.useState(() => "")
+  let (newD2, setNewD2) = React.useState(() => "")
+  let (newD4, setNewD4) = React.useState(() => "")
+  let (newD8, setNewD8) = React.useState(() => "")
+  let (newAccount, setNewAccount) = React.useState(() => "")
+  let (accountSlot, setAccountSlot) = React.useState(() => 0)
+  let (showAccounts, setShowAccounts) = React.useState(() => false)
+  let (showDiscriminators, setShowDiscriminators) = React.useState(() => true)
+
+  let updateField = (newState: filterState) => onFilterChange(newState)
+
+  let addToList = (current: option<array<string>>, value: string): option<array<string>> => {
+    Some(Array.concat(current->Option.getOr([]), [value]))
+  }
+
+  let removeFromList = (current: option<array<string>>, idx: int): option<array<string>> => {
+    let cur = current->Option.getOr([])
+    let next = Belt.Array.keepWithIndex(cur, (_, i) => i !== idx)
+    Array.length(next) > 0 ? Some(next) : None
+  }
+
+  let getAccountAt = (state: filterState, slot: int): option<array<string>> =>
+    switch slot {
+    | 0 => state.a0
+    | 1 => state.a1
+    | 2 => state.a2
+    | 3 => state.a3
+    | 4 => state.a4
+    | 5 => state.a5
+    | 6 => state.a6
+    | 7 => state.a7
+    | 8 => state.a8
+    | 9 => state.a9
+    | _ => None
+    }
+
+  let setAccountAt = (state: filterState, slot: int, v: option<array<string>>): filterState =>
+    switch slot {
+    | 0 => {...state, a0: v}
+    | 1 => {...state, a1: v}
+    | 2 => {...state, a2: v}
+    | 3 => {...state, a3: v}
+    | 4 => {...state, a4: v}
+    | 5 => {...state, a5: v}
+    | 6 => {...state, a6: v}
+    | 7 => {...state, a7: v}
+    | 8 => {...state, a8: v}
+    | 9 => {...state, a9: v}
+    | _ => state
+    }
+
+  let activeAccountSlots = () => {
+    let slots = ref([])
+    for i in 0 to 9 {
+      switch getAccountAt(filterState, i) {
+      | Some(arr) if Array.length(arr) > 0 => slots := Array.concat(slots.contents, [i])
+      | _ => ()
+      }
+    }
+    slots.contents
+  }
+
+  let hasFilters =
+    Option.isSome(filterState.programId) ||
+    Option.isSome(filterState.d1) ||
+    Option.isSome(filterState.d2) ||
+    Option.isSome(filterState.d4) ||
+    Option.isSome(filterState.d8) ||
+    Array.length(activeAccountSlots()) > 0 ||
+    Option.isSome(filterState.isInner)
+
+  <div
+    className="relative bg-white rounded-xl border border-slate-200 shadow-sm transition-all w-full">
+    <div className="p-4 border-b border-slate-100">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <h3 className="text-lg font-medium text-slate-900">
+            {`Instruction Filter ${Int.toString(filterIndex + 1)}`->React.string}
+          </h3>
+          {hasFilters
+            ? <span
+                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700">
+                {"Active"->React.string}
+              </span>
+            : React.null}
+        </div>
+        <div className="flex items-center space-x-1">
+          <button
+            onClick={_ => onToggleExpand()}
+            className="inline-flex items-center p-2 text-sm font-medium text-slate-500 hover:text-slate-700 hover:bg-slate-50 rounded-lg transition-colors">
+            <svg
+              className={`w-4 h-4 transform transition-transform ${isExpanded
+                  ? "rotate-180"
+                  : "rotate-0"}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+          <button
+            onClick={_ => onRemove()}
+            className="inline-flex items-center p-2 text-sm font-medium text-red-500 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    {isExpanded
+      ? <div className="p-6">
+          // Program IDs
+          {renderListEditor(
+            ~label="Program IDs (base58)",
+            ~placeholder="e.g. TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            ~values=filterState.programId->Option.getOr([]),
+            ~onAdd=v => {
+              if isBase58Pubkey(v) {
+                updateField({...filterState, programId: addToList(filterState.programId, v)})
+                setNewProgramId(_ => "")
+              }
+            },
+            ~onRemove=i =>
+              updateField({...filterState, programId: removeFromList(filterState.programId, i)}),
+            ~draft=newProgramId,
+            ~setDraft=setNewProgramId,
+            ~validate=isBase58Pubkey,
+          )}
+
+          // Discriminators
+          <div className="mb-4">
+            <button
+              onClick={_ => setShowDiscriminators(prev => !prev)}
+              className="flex items-center text-xs font-semibold text-slate-700 hover:text-slate-900 mb-2">
+              <svg
+                className={`w-3 h-3 mr-1 transform transition-transform ${showDiscriminators
+                    ? "rotate-90"
+                    : ""}`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+              </svg>
+              {"Instruction Discriminators (hex)"->React.string}
+            </button>
+            {showDiscriminators
+              ? <div className="pl-4 border-l-2 border-slate-100">
+                  {renderListEditor(
+                    ~label="d1 (1 byte) - SPL Token style",
+                    ~placeholder="0x03",
+                    ~values=filterState.d1->Option.getOr([]),
+                    ~onAdd=v => {
+                      if isHexBytes(v, 1) {
+                        updateField({...filterState, d1: addToList(filterState.d1, v)})
+                        setNewD1(_ => "")
+                      }
+                    },
+                    ~onRemove=i =>
+                      updateField({...filterState, d1: removeFromList(filterState.d1, i)}),
+                    ~draft=newD1,
+                    ~setDraft=setNewD1,
+                    ~validate=v => isHexBytes(v, 1),
+                  )}
+                  {renderListEditor(
+                    ~label="d2 (2 bytes)",
+                    ~placeholder="0x0103",
+                    ~values=filterState.d2->Option.getOr([]),
+                    ~onAdd=v => {
+                      if isHexBytes(v, 2) {
+                        updateField({...filterState, d2: addToList(filterState.d2, v)})
+                        setNewD2(_ => "")
+                      }
+                    },
+                    ~onRemove=i =>
+                      updateField({...filterState, d2: removeFromList(filterState.d2, i)}),
+                    ~draft=newD2,
+                    ~setDraft=setNewD2,
+                    ~validate=v => isHexBytes(v, 2),
+                  )}
+                  {renderListEditor(
+                    ~label="d4 (4 bytes) - System Program style",
+                    ~placeholder="0x02000000",
+                    ~values=filterState.d4->Option.getOr([]),
+                    ~onAdd=v => {
+                      if isHexBytes(v, 4) {
+                        updateField({...filterState, d4: addToList(filterState.d4, v)})
+                        setNewD4(_ => "")
+                      }
+                    },
+                    ~onRemove=i =>
+                      updateField({...filterState, d4: removeFromList(filterState.d4, i)}),
+                    ~draft=newD4,
+                    ~setDraft=setNewD4,
+                    ~validate=v => isHexBytes(v, 4),
+                  )}
+                  {renderListEditor(
+                    ~label="d8 (8 bytes) - Anchor discriminator",
+                    ~placeholder="0xf8c69e91e17587c8",
+                    ~values=filterState.d8->Option.getOr([]),
+                    ~onAdd=v => {
+                      if isHexBytes(v, 8) {
+                        updateField({...filterState, d8: addToList(filterState.d8, v)})
+                        setNewD8(_ => "")
+                      }
+                    },
+                    ~onRemove=i =>
+                      updateField({...filterState, d8: removeFromList(filterState.d8, i)}),
+                    ~draft=newD8,
+                    ~setDraft=setNewD8,
+                    ~validate=v => isHexBytes(v, 8),
+                  )}
+                </div>
+              : React.null}
+          </div>
+
+          // Account position filters
+          <div className="mb-4">
+            <button
+              onClick={_ => setShowAccounts(prev => !prev)}
+              className="flex items-center text-xs font-semibold text-slate-700 hover:text-slate-900 mb-2">
+              <svg
+                className={`w-3 h-3 mr-1 transform transition-transform ${showAccounts
+                    ? "rotate-90"
+                    : ""}`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+              </svg>
+              {`Account Position Filters (a0..a9)${Array.length(activeAccountSlots()) > 0
+                  ? ` - ${Int.toString(Array.length(activeAccountSlots()))} active`
+                  : ""}`->React.string}
+            </button>
+            {showAccounts
+              ? <div className="pl-4 border-l-2 border-slate-100">
+                  <div className="flex space-x-2 mb-2">
+                    <select
+                      value={Int.toString(accountSlot)}
+                      onChange={e => {
+                        let target = ReactEvent.Form.target(e)
+                        switch Int.fromString(target["value"]) {
+                        | Some(n) => setAccountSlot(_ => n)
+                        | None => ()
+                        }
+                      }}
+                      className="border border-slate-300 rounded-lg px-2 py-2 text-xs">
+                      {Belt.Array.range(0, 9)
+                      ->Array.map(i =>
+                        <option key={Int.toString(i)} value={Int.toString(i)}>
+                          {`a${Int.toString(i)}`->React.string}
+                        </option>
+                      )
+                      ->React.array}
+                    </select>
+                    <input
+                      type_="text"
+                      value={newAccount}
+                      onChange={e => {
+                        let target = ReactEvent.Form.target(e)
+                        setNewAccount(_ => target["value"])
+                      }}
+                      placeholder="base58 pubkey"
+                      className={inputClass}
+                    />
+                    <button
+                      onClick={_ => {
+                        if isBase58Pubkey(newAccount) {
+                          let cur = getAccountAt(filterState, accountSlot)
+                          updateField(
+                            setAccountAt(filterState, accountSlot, addToList(cur, newAccount)),
+                          )
+                          setNewAccount(_ => "")
+                        }
+                      }}
+                      disabled={String.length(newAccount) === 0 || !isBase58Pubkey(newAccount)}
+                      className={addBtnClass}>
+                      {"Add"->React.string}
+                    </button>
+                  </div>
+                  {activeAccountSlots()
+                  ->Array.map(slot => {
+                    let values = getAccountAt(filterState, slot)->Option.getOr([])
+                    <div key={Int.toString(slot)} className="mb-3">
+                      <div className="text-xs text-slate-600 mb-1">
+                        {`Position a${Int.toString(slot)}`->React.string}
+                      </div>
+                      <div className="space-y-1">
+                        {values
+                        ->Array.mapWithIndex((v, i) =>
+                          <div key={Int.toString(i)} className={chipClass}>
+                            <span className="text-xs font-mono text-slate-800 truncate">
+                              {v->React.string}
+                            </span>
+                            <button
+                              onClick={_ => {
+                                let cur = getAccountAt(filterState, slot)
+                                updateField(
+                                  setAccountAt(filterState, slot, removeFromList(cur, i)),
+                                )
+                              }}
+                              className="ml-2 text-red-600 hover:text-red-800 text-xs">
+                              {"Remove"->React.string}
+                            </button>
+                          </div>
+                        )
+                        ->React.array}
+                      </div>
+                    </div>
+                  })
+                  ->React.array}
+                </div>
+              : React.null}
+          </div>
+
+          // is_inner toggle
+          <div className="mb-4">
+            <label className={labelClass}> {"Is Inner Instruction (CPI)"->React.string} </label>
+            <div className="flex space-x-2">
+              {[("Both", None), ("Inner only", Some(true)), ("Outer only", Some(false))]
+              ->Array.map(((label, value)) => {
+                let isActive = filterState.isInner === value
+                <button
+                  key={label}
+                  onClick={_ => updateField({...filterState, isInner: value})}
+                  className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-colors ${isActive
+                      ? "bg-slate-800 text-white border-slate-800"
+                      : "bg-white text-slate-700 border-slate-200 hover:bg-slate-50"}`}>
+                  {label->React.string}
+                </button>
+              })
+              ->React.array}
+            </div>
+          </div>
+
+          // Joins
+          <div>
+            <label className={labelClass}> {"Joins"->React.string} </label>
+            <div className="flex flex-wrap gap-3">
+              <label className="inline-flex items-center text-xs text-slate-700 cursor-pointer">
+                <input
+                  type_="checkbox"
+                  checked={filterState.includeTransaction}
+                  onChange={e => {
+                    let target = ReactEvent.Form.target(e)
+                    updateField({...filterState, includeTransaction: target["checked"]})
+                  }}
+                  className="mr-2"
+                />
+                {"include_transaction"->React.string}
+              </label>
+              <label className="inline-flex items-center text-xs text-slate-700 cursor-pointer">
+                <input
+                  type_="checkbox"
+                  checked={filterState.includeLogs}
+                  onChange={e => {
+                    let target = ReactEvent.Form.target(e)
+                    updateField({...filterState, includeLogs: target["checked"]})
+                  }}
+                  className="mr-2"
+                />
+                {"include_logs"->React.string}
+              </label>
+            </div>
+          </div>
+        </div>
+      : React.null}
+  </div>
+}

--- a/src/SolanaLogFilter.res
+++ b/src/SolanaLogFilter.res
@@ -1,0 +1,234 @@
+open SolanaQueryStructure
+
+type filterState = SolanaQueryStructure.logSelection
+
+let labelClass = "block text-xs font-medium text-slate-700 mb-1"
+let inputClass = "flex-1 border border-slate-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-colors"
+let addBtnClass = "px-3 py-2 bg-slate-700 text-white text-xs font-medium rounded-lg hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 disabled:opacity-50 transition-colors"
+let chipClass = "flex items-center justify-between bg-slate-50 px-3 py-1.5 rounded-lg border border-slate-100"
+
+let isBase58Pubkey = SolanaInstructionFilter.isBase58Pubkey
+
+@react.component
+let make = (
+  ~filterState: filterState,
+  ~onFilterChange: filterState => unit,
+  ~onRemove: unit => unit,
+  ~filterIndex: int,
+  ~isExpanded: bool,
+  ~onToggleExpand: unit => unit,
+) => {
+  let (newProgramId, setNewProgramId) = React.useState(() => "")
+  let (newKind, setNewKind) = React.useState(() => "")
+
+  let updateField = (newState: filterState) => onFilterChange(newState)
+
+  let addProgramId = (v: string) => {
+    if isBase58Pubkey(v) {
+      updateField({
+        ...filterState,
+        programId: Some(Array.concat(filterState.programId->Option.getOr([]), [v])),
+      })
+      setNewProgramId(_ => "")
+    }
+  }
+
+  let removeProgramId = (idx: int) => {
+    let cur = filterState.programId->Option.getOr([])
+    let next = Belt.Array.keepWithIndex(cur, (_, i) => i !== idx)
+    updateField({...filterState, programId: Array.length(next) > 0 ? Some(next) : None})
+  }
+
+  let addKind = (v: string) => {
+    let trimmed = String.trim(v)
+    if String.length(trimmed) > 0 {
+      updateField({
+        ...filterState,
+        kind: Some(Array.concat(filterState.kind->Option.getOr([]), [trimmed])),
+      })
+      setNewKind(_ => "")
+    }
+  }
+
+  let removeKind = (idx: int) => {
+    let cur = filterState.kind->Option.getOr([])
+    let next = Belt.Array.keepWithIndex(cur, (_, i) => i !== idx)
+    updateField({...filterState, kind: Array.length(next) > 0 ? Some(next) : None})
+  }
+
+  let hasFilters = Option.isSome(filterState.programId) || Option.isSome(filterState.kind)
+
+  <div
+    className="relative bg-white rounded-xl border border-slate-200 shadow-sm transition-all w-full">
+    <div className="p-4 border-b border-slate-100">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <h3 className="text-lg font-medium text-slate-900">
+            {`Log Filter ${Int.toString(filterIndex + 1)}`->React.string}
+          </h3>
+          {hasFilters
+            ? <span
+                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700">
+                {"Active"->React.string}
+              </span>
+            : React.null}
+        </div>
+        <div className="flex items-center space-x-1">
+          <button
+            onClick={_ => onToggleExpand()}
+            className="inline-flex items-center p-2 text-sm font-medium text-slate-500 hover:text-slate-700 hover:bg-slate-50 rounded-lg transition-colors">
+            <svg
+              className={`w-4 h-4 transform transition-transform ${isExpanded
+                  ? "rotate-180"
+                  : "rotate-0"}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+          <button
+            onClick={_ => onRemove()}
+            className="inline-flex items-center p-2 text-sm font-medium text-red-500 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    {isExpanded
+      ? <div className="p-6">
+          // Program IDs
+          <div className="mb-4">
+            <label className={labelClass}> {"Program IDs (base58)"->React.string} </label>
+            <div className="flex space-x-2 mb-2">
+              <input
+                type_="text"
+                value={newProgramId}
+                onChange={e => {
+                  let target = ReactEvent.Form.target(e)
+                  setNewProgramId(_ => target["value"])
+                }}
+                onKeyDown={e =>
+                  if ReactEvent.Keyboard.key(e) === "Enter" {
+                    ReactEvent.Synthetic.preventDefault(e)
+                    addProgramId(newProgramId)
+                  }}
+                placeholder="base58 program pubkey"
+                className={inputClass}
+              />
+              <button
+                onClick={_ => addProgramId(newProgramId)}
+                disabled={String.length(newProgramId) === 0 || !isBase58Pubkey(newProgramId)}
+                className={addBtnClass}>
+                {(
+                  Array.length(filterState.programId->Option.getOr([])) > 0 ? "Add (OR)" : "Add"
+                )->React.string}
+              </button>
+            </div>
+            <div className="space-y-1">
+              {filterState.programId
+              ->Option.getOr([])
+              ->Array.mapWithIndex((v, i) =>
+                <div key={Int.toString(i)} className={chipClass}>
+                  <span className="text-xs font-mono text-slate-800 truncate">
+                    {v->React.string}
+                  </span>
+                  <button
+                    onClick={_ => removeProgramId(i)}
+                    className="ml-2 text-red-600 hover:text-red-800 text-xs font-medium transition-colors">
+                    {"Remove"->React.string}
+                  </button>
+                </div>
+              )
+              ->React.array}
+            </div>
+          </div>
+
+          // Kind
+          <div className="mb-4">
+            <label className={labelClass}> {"Log Kind (e.g. log, data)"->React.string} </label>
+            <div className="flex space-x-2 mb-2">
+              <input
+                type_="text"
+                value={newKind}
+                onChange={e => {
+                  let target = ReactEvent.Form.target(e)
+                  setNewKind(_ => target["value"])
+                }}
+                onKeyDown={e =>
+                  if ReactEvent.Keyboard.key(e) === "Enter" {
+                    ReactEvent.Synthetic.preventDefault(e)
+                    addKind(newKind)
+                  }}
+                placeholder="log | data"
+                className={inputClass}
+              />
+              <button
+                onClick={_ => addKind(newKind)}
+                disabled={String.length(String.trim(newKind)) === 0}
+                className={addBtnClass}>
+                {(
+                  Array.length(filterState.kind->Option.getOr([])) > 0 ? "Add (OR)" : "Add"
+                )->React.string}
+              </button>
+            </div>
+            <div className="space-y-1">
+              {filterState.kind
+              ->Option.getOr([])
+              ->Array.mapWithIndex((v, i) =>
+                <div key={Int.toString(i)} className={chipClass}>
+                  <span className="text-xs font-mono text-slate-800"> {v->React.string} </span>
+                  <button
+                    onClick={_ => removeKind(i)}
+                    className="ml-2 text-red-600 hover:text-red-800 text-xs font-medium transition-colors">
+                    {"Remove"->React.string}
+                  </button>
+                </div>
+              )
+              ->React.array}
+            </div>
+          </div>
+
+          // Joins
+          <div>
+            <label className={labelClass}> {"Joins"->React.string} </label>
+            <div className="flex flex-wrap gap-3">
+              <label className="inline-flex items-center text-xs text-slate-700 cursor-pointer">
+                <input
+                  type_="checkbox"
+                  checked={filterState.includeTransaction}
+                  onChange={e => {
+                    let target = ReactEvent.Form.target(e)
+                    updateField({...filterState, includeTransaction: target["checked"]})
+                  }}
+                  className="mr-2"
+                />
+                {"include_transaction"->React.string}
+              </label>
+              <label className="inline-flex items-center text-xs text-slate-700 cursor-pointer">
+                <input
+                  type_="checkbox"
+                  checked={filterState.includeInstruction}
+                  onChange={e => {
+                    let target = ReactEvent.Form.target(e)
+                    updateField({...filterState, includeInstruction: target["checked"]})
+                  }}
+                  className="mr-2"
+                />
+                {"include_instruction"->React.string}
+              </label>
+            </div>
+          </div>
+        </div>
+      : React.null}
+  </div>
+}

--- a/src/SolanaQueryResults.res
+++ b/src/SolanaQueryResults.res
@@ -1,0 +1,977 @@
+open SolanaQueryStructure
+open Fetch
+
+type activeTab = QueryJson | Results
+type resultsView = Raw | Table
+type rawMode = Plain | Interactive
+
+let solanaEndpoint = "https://solana-near-head-test.hypersync.xyz/query"
+
+let strList = (arr: array<string>): string =>
+  arr->Array.map(s => `"${s}"`)->Array.join(", ")
+
+let serializeInstructionFilter = (sel: instructionSelection): string => {
+  let parts: array<option<string>> = [
+    switch sel.programId {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"program_id": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.d1 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"d1": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.d2 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"d2": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.d4 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"d4": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.d8 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"d8": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.a0 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"a0": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.a1 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"a1": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.a2 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"a2": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.a3 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"a3": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.a4 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"a4": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.a5 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"a5": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.a6 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"a6": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.a7 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"a7": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.a8 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"a8": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.a9 {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"a9": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.isInner {
+    | Some(true) => Some(`"is_inner": true`)
+    | Some(false) => Some(`"is_inner": false`)
+    | None => None
+    },
+    sel.includeTransaction ? Some(`"include_transaction": true`) : None,
+    sel.includeLogs ? Some(`"include_logs": true`) : None,
+  ]
+  let active = parts->Array.filterMap(x => x)
+  `{${Array.join(active, ", ")}}`
+}
+
+let serializeTransactionFilter = (sel: transactionSelection): string => {
+  let parts: array<option<string>> = [
+    switch sel.feePayer {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"fee_payer": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.success {
+    | Some(true) => Some(`"success": true`)
+    | Some(false) => Some(`"success": false`)
+    | None => None
+    },
+    sel.includeInstructions ? Some(`"include_instructions": true`) : None,
+  ]
+  let active = parts->Array.filterMap(x => x)
+  `{${Array.join(active, ", ")}}`
+}
+
+let serializeLogFilter = (sel: logSelection): string => {
+  let parts: array<option<string>> = [
+    switch sel.programId {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"program_id": [${strList(arr)}]`)
+    | _ => None
+    },
+    switch sel.kind {
+    | Some(arr) if Array.length(arr) > 0 => Some(`"kind": [${strList(arr)}]`)
+    | _ => None
+    },
+    sel.includeTransaction ? Some(`"include_transaction": true`) : None,
+    sel.includeInstruction ? Some(`"include_instruction": true`) : None,
+  ]
+  let active = parts->Array.filterMap(x => x)
+  `{${Array.join(active, ", ")}}`
+}
+
+let serializeFields = (fs: fieldSelection): string => {
+  let blockArr = fs.block->Array.map(f => `"${blockFieldToSnake(f)}"`)->Array.join(", ")
+  let txnArr =
+    fs.transaction->Array.map(f => `"${transactionFieldToSnake(f)}"`)->Array.join(", ")
+  let instrArr =
+    fs.instruction->Array.map(f => `"${instructionFieldToSnake(f)}"`)->Array.join(", ")
+  let logArr = fs.log->Array.map(f => `"${logFieldToSnake(f)}"`)->Array.join(", ")
+  let balArr = fs.balance->Array.map(f => `"${balanceFieldToSnake(f)}"`)->Array.join(", ")
+  let tbArr =
+    fs.tokenBalance->Array.map(f => `"${tokenBalanceFieldToSnake(f)}"`)->Array.join(", ")
+  let rewArr = fs.reward->Array.map(f => `"${rewardFieldToSnake(f)}"`)->Array.join(", ")
+  `"fields": {
+    "block": [${blockArr}],
+    "transaction": [${txnArr}],
+    "instruction": [${instrArr}],
+    "log": [${logArr}],
+    "balance": [${balArr}],
+    "token_balance": [${tbArr}],
+    "reward": [${rewArr}]
+  }`
+}
+
+let serializeQuery = (q: query): string => {
+  let parts: array<option<string>> = [
+    Some(`"from_slot": ${Int.toString(q.fromSlot)}`),
+    switch q.toSlot {
+    | Some(v) => Some(`"to_slot": ${Int.toString(v)}`)
+    | None => None
+    },
+    switch q.instructions {
+    | Some(arr) if Array.length(arr) > 0 =>
+      let body = arr->Array.map(serializeInstructionFilter)->Array.join(",\n    ")
+      Some(`"instructions": [
+    ${body}
+  ]`)
+    | _ => None
+    },
+    switch q.transactions {
+    | Some(arr) if Array.length(arr) > 0 =>
+      let body = arr->Array.map(serializeTransactionFilter)->Array.join(",\n    ")
+      Some(`"transactions": [
+    ${body}
+  ]`)
+    | _ => None
+    },
+    switch q.logs {
+    | Some(arr) if Array.length(arr) > 0 =>
+      let body = arr->Array.map(serializeLogFilter)->Array.join(",\n    ")
+      Some(`"logs": [
+    ${body}
+  ]`)
+    | _ => None
+    },
+    switch q.includeAllBlocks {
+    | Some(true) => Some(`"include_all_blocks": true`)
+    | Some(false) => Some(`"include_all_blocks": false`)
+    | None => None
+    },
+    Some(serializeFields(q.fields)),
+    switch q.maxNumBlocks {
+    | Some(v) => Some(`"max_num_blocks": ${Int.toString(v)}`)
+    | None => None
+    },
+    switch q.maxNumTransactions {
+    | Some(v) => Some(`"max_num_transactions": ${Int.toString(v)}`)
+    | None => None
+    },
+    switch q.maxNumInstructions {
+    | Some(v) => Some(`"max_num_instructions": ${Int.toString(v)}`)
+    | None => None
+    },
+    switch q.maxNumLogs {
+    | Some(v) => Some(`"max_num_logs": ${Int.toString(v)}`)
+    | None => None
+    },
+  ]
+  let active = parts->Array.filterMap(x => x)
+  `{
+  ${Array.join(active, ",\n  ")}
+}`
+}
+
+@react.component
+let make = (
+  ~query: query,
+  ~executeSignal: int,
+  ~bearerToken: option<string>,
+) => {
+  let (activeTab, setActiveTab) = React.useState(() => QueryJson)
+  let (isExecuting, setIsExecuting) = React.useState(() => false)
+  let (queryResult, setQueryResult) = React.useState(() => None)
+  let (queryError, setQueryError) = React.useState(() => None)
+  let (queryResultJson, setQueryResultJson) = React.useState(() => None)
+  let (resultsView, setResultsView) = React.useState(() => Table)
+  let (rawMode, setRawMode) = React.useState(() => Plain)
+  let (clientMs, setClientMs) = React.useState(() => None)
+  let (serverMs, setServerMs) = React.useState(() => None)
+  let (responseBytes, setResponseBytes) = React.useState(() => None)
+  let (selectedDataset, setSelectedDataset) = React.useState(() => None)
+  let (sortColumn, setSortColumn) = React.useState(() => None)
+  let (sortAscending, setSortAscending) = React.useState(() => true)
+  let (copiedCurl, setCopiedCurl) = React.useState(() => false)
+  let (copiedJson, setCopiedJson) = React.useState(() => false)
+  let (copiedResults, setCopiedResults) = React.useState(() => false)
+
+  let isFirstRender = React.useRef(true)
+  React.useEffect1(() => {
+    if isFirstRender.current {
+      isFirstRender.current = false
+    } else if activeTab === Results {
+      setActiveTab(_ => QueryJson)
+    }
+    None
+  }, [query])
+
+  let executeQuery = async () => {
+    setActiveTab(_ => Results)
+    setIsExecuting(_ => true)
+    setQueryError(_ => None)
+    setQueryResult(_ => None)
+    setQueryResultJson(_ => None)
+    setClientMs(_ => None)
+    setServerMs(_ => None)
+    setResponseBytes(_ => None)
+    setSelectedDataset(_ => None)
+
+    try {
+      let body = serializeQuery(query)
+      let calcByteLength: string => int = %raw(`(s) => new TextEncoder().encode(s).length`)
+      let t0: float = %raw("performance.now()")
+      let headers = switch bearerToken {
+      | Some(token) =>
+        Headers.fromObject({
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${token}`,
+        })
+      | None => Headers.fromObject({"Content-Type": "application/json"})
+      }
+      let requestInit = makeRequestInit({
+        "method": "POST",
+        "body": Body.string(body),
+        "headers": headers,
+      })
+      let response = await fetch(solanaEndpoint, requestInit)
+      let resultTextRaw = await response->Response.text
+      let t1: float = %raw("performance.now()")
+      let clientElapsed = t1 -. t0
+      setClientMs(_ => Some(Float.toInt(clientElapsed)))
+      setResponseBytes(_ => Some(calcByteLength(resultTextRaw)))
+      let resultJson = try {JSON.parseOrThrow(resultTextRaw)} catch {
+      | _ => JSON.Encode.string(resultTextRaw)
+      }
+      if response->Response.ok {
+        try {
+          let resultText = JSON.stringify(resultJson, ~space=2)
+          setQueryResult(_ => Some(resultText))
+          setQueryResultJson(_ => Some(resultJson))
+          let serverDurationMs =
+            resultJson
+            ->JSON.Decode.object
+            ->Option.flatMap(d => Dict.get(d, "total_execution_time_ms"))
+            ->Option.flatMap(JSON.Decode.float)
+            ->Option.map(Float.toInt)
+          setServerMs(_ => serverDurationMs)
+        } catch {
+        | _ => setQueryError(_ => Some("Failed to stringify response JSON"))
+        }
+      } else {
+        setQueryError(_ => Some(`HTTP ${Int.toString(response->Response.status)}: ${resultTextRaw}`))
+      }
+    } catch {
+    | _ => setQueryError(_ => Some("Network error occurred"))
+    }
+    setIsExecuting(_ => false)
+  }
+
+  React.useEffect1(() => {
+    // Skip auto-execute on mount; only run when the user explicitly fires it
+    if executeSignal > 0 {
+      executeQuery()->ignore
+    }
+    None
+  }, [executeSignal])
+
+  let generateCurlCommand = () => {
+    let body = serializeQuery(query)
+    let escaped = String.replaceAll(body, "\"", "\\\"")
+    let authHeader = switch bearerToken {
+    | Some(token) => `\n  -H "Authorization: Bearer ${token}" \\`
+    | None => ""
+    }
+    `curl -X POST "${solanaEndpoint}" \\
+  -H "Content-Type: application/json" \\${authHeader}
+  -d "${escaped}"`
+  }
+
+  let copyToClipboard: string => unit = %raw(`(text) => {
+    navigator.clipboard.writeText(text).catch(() => {})
+  }`)
+
+  let copyCurl = () => {
+    copyToClipboard(generateCurlCommand())
+    setCopiedCurl(_ => true)
+    let _: timeoutId = setTimeout(() => setCopiedCurl(_ => false), 2000)
+  }
+
+  let copyJson = () => {
+    copyToClipboard(serializeQuery(query))
+    setCopiedJson(_ => true)
+    let _: timeoutId = setTimeout(() => setCopiedJson(_ => false), 2000)
+  }
+
+  let downloadJson = () => {
+    let jsonText = serializeQuery(query)
+    let triggerDownload: string => unit = %raw(`(text) => {
+      const blob = new Blob([text], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'hypersync-solana-query.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }`)
+    triggerDownload(jsonText)
+  }
+
+  let copyResultsJson = () =>
+    switch queryResult {
+    | Some(r) =>
+      copyToClipboard(r)
+      setCopiedResults(_ => true)
+      let _: timeoutId = setTimeout(() => setCopiedResults(_ => false), 2000)
+    | None => ()
+    }
+
+  let formatBytes: int => string = %raw(`(b) => {
+    if (b < 1024) return b + ' B';
+    if (b < 1024*1024) return (Math.round(b/102.4)/10) + ' KB';
+    return (Math.round(b/104857.6)/10) + ' MB';
+  }`)
+
+  // Solana response: { blocks: Vec<Vec<row>>, transactions: ..., ... }
+  // Flatten the outer batches into a single row array
+  // Only include datasets that actually have rows, so the switcher matches reality
+  let solanaDatasetNames: JSON.t => array<string> = %raw(`(data) => {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) return [];
+    const known = ['blocks','transactions','instructions','logs','balances','token_balances','rewards'];
+    const out = [];
+    for (const k of known) {
+      const v = data[k];
+      if (!Array.isArray(v)) continue;
+      let total = 0;
+      for (const batch of v) {
+        if (Array.isArray(batch)) total += batch.length;
+        else total += 1;
+        if (total > 0) break;
+      }
+      if (total > 0) out.push(k);
+    }
+    return out;
+  }`)
+
+  let solanaDatasetRows: (JSON.t, string) => array<JSON.t> = %raw(`(data, name) => {
+    if (!data || typeof data !== 'object') return [];
+    const v = data[name];
+    if (!Array.isArray(v)) return [];
+    // v is Vec<Vec<row>> — flatten
+    let out = [];
+    for (const batch of v) {
+      if (Array.isArray(batch)) out = out.concat(batch);
+      else out.push(batch);
+    }
+    return out;
+  }`)
+
+  let flattenRows: array<JSON.t> => array<dict<string>> = %raw(`(rows) => {
+    const flat = (obj, prefix) => {
+      const out = {};
+      const stack = [[obj, prefix]];
+      while (stack.length) {
+        const [cur, pre] = stack.pop();
+        if (cur && typeof cur === 'object' && !Array.isArray(cur)) {
+          for (const k in cur) {
+            if (!Object.prototype.hasOwnProperty.call(cur, k)) continue;
+            const v = cur[k];
+            const nk = pre ? pre + '.' + k : k;
+            if (v && typeof v === 'object' && !Array.isArray(v)) stack.push([v, nk]);
+            else if (Array.isArray(v)) out[nk] = JSON.stringify(v);
+            else out[nk] = v == null ? '' : String(v);
+          }
+        } else {
+          out[pre || 'value'] = cur == null ? '' : String(cur);
+        }
+      }
+      return out;
+    };
+    return rows.map(r => flat(r, ''));
+  }`)
+
+  let detectColumns: array<dict<string>> => array<string> = %raw(`(flatRows) => {
+    const cols = new Set();
+    for (let i = 0; i < flatRows.length && i < 200; i++) {
+      const r = flatRows[i];
+      for (const k in r) cols.add(k);
+    }
+    return Array.from(cols).sort();
+  }`)
+
+  let analyzeColumns: array<dict<string>> => dict<string> = %raw(`(flatRows) => {
+    const isNumeric = (v) => typeof v === 'string' && /^-?\d+(?:\.\d+)?$/.test(v.trim());
+    const counts = new Map();
+    for (let i = 0; i < flatRows.length && i < 200; i++) {
+      const r = flatRows[i];
+      for (const k in r) {
+        const v = r[k];
+        const t = isNumeric(v) ? 'numeric' : 'text';
+        const m = counts.get(k) || { numeric: 0, text: 0 };
+        m[t]++;
+        counts.set(k, m);
+      }
+    }
+    const out = {};
+    counts.forEach((m, k) => { out[k] = (m.numeric >= m.text) ? 'numeric' : 'text'; });
+    return out;
+  }`)
+
+  let sortFlatRows: (
+    array<dict<string>>,
+    string,
+    string,
+    bool,
+  ) => array<dict<string>> = %raw(`(rows, col, colType, asc) => {
+    const arr = rows.slice();
+    const cmp = (a, b) => {
+      const av = a[col];
+      const bv = b[col];
+      if (colType === 'numeric') {
+        const an = parseFloat(av ?? '0');
+        const bn = parseFloat(bv ?? '0');
+        return an === bn ? 0 : (an < bn ? -1 : 1);
+      }
+      return String(av ?? '').localeCompare(String(bv ?? ''));
+    };
+    arr.sort((a, b) => asc ? cmp(a, b) : -cmp(a, b));
+    return arr;
+  }`)
+
+  let rowsToCsv: array<dict<string>> => string = %raw(`(flatRows) => {
+    const cols = (() => {
+      const s = new Set();
+      for (let i = 0; i < flatRows.length && i < 200; i++) { for (const k in flatRows[i]) s.add(k); }
+      return Array.from(s).sort();
+    })();
+    const esc = (v) => {
+      if (v == null) return '';
+      const s = String(v);
+      if (s.includes('"') || s.includes(',') || s.includes('\n')) return '"' + s.replaceAll('"','""') + '"';
+      return s;
+    };
+    const lines = [cols.join(',')];
+    for (let i = 0; i < flatRows.length && i < 1000; i++) {
+      lines.push(cols.map(c => esc(flatRows[i][c])).join(','));
+    }
+    return lines.join('\n');
+  }`)
+
+  let downloadCsv = (csv: string) => {
+    let trigger: string => unit = %raw(`(text) => {
+      const blob = new Blob([text], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'hypersync-solana-results.csv';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }`)
+    trigger(csv)
+  }
+
+  let smartTruncate = (text: string, maxLength: int): string => {
+    if String.length(text) <= maxLength {
+      text
+    } else {
+      let half = maxLength / 2 - 2
+      let start = String.substring(text, ~start=0, ~end=half)
+      let end = String.substring(text, ~start=String.length(text) - half)
+      start ++ "..." ++ end
+    }
+  }
+
+  let copyText: string => unit = %raw(`(text) => {
+    navigator.clipboard && navigator.clipboard.writeText(text).catch(() => {});
+  }`)
+
+  let fixedColumnWidth = "200px"
+
+  let rec renderJsonNode = (label: string, node: JSON.t, depth: int): React.element => {
+    let indent = depth > 0 ? "ml-4" : ""
+    switch node {
+    | JSON.String(s) =>
+      <div className={`text-xs ${indent} font-mono text-slate-800`}>
+        {`${label}: "${s}"`->React.string}
+      </div>
+    | JSON.Number(n) =>
+      <div className={`text-xs ${indent} font-mono text-slate-800`}>
+        {`${label}: ${Float.toString(n)}`->React.string}
+      </div>
+    | JSON.Boolean(true) =>
+      <div className={`text-xs ${indent} font-mono text-slate-800`}>
+        {`${label}: true`->React.string}
+      </div>
+    | JSON.Boolean(false) =>
+      <div className={`text-xs ${indent} font-mono text-slate-800`}>
+        {`${label}: false`->React.string}
+      </div>
+    | JSON.Null =>
+      <div className={`text-xs ${indent} font-mono text-slate-500`}>
+        {`${label}: null`->React.string}
+      </div>
+    | JSON.Array(arr) =>
+      <details className={`text-xs ${indent}`} open_={depth < 1}>
+        <summary className="cursor-pointer font-mono text-slate-700">
+          {`${label} [${Int.toString(Array.length(arr))}]`->React.string}
+        </summary>
+        <div className="mt-1">
+          {arr
+          ->Array.mapWithIndex((v, i) => renderJsonNode(Int.toString(i), v, depth + 1))
+          ->React.array}
+        </div>
+      </details>
+    | JSON.Object(obj) =>
+      let keys = Dict.keysToArray(obj)
+      <details className={`text-xs ${indent}`} open_={depth < 1}>
+        <summary className="cursor-pointer font-mono text-slate-700">
+          {`${label} {}`->React.string}
+        </summary>
+        <div className="mt-1">
+          {keys
+          ->Array.map(k => {
+            let v = Dict.get(obj, k)->Option.getOr(JSON.Encode.null)
+            renderJsonNode(k, v, depth + 1)
+          })
+          ->React.array}
+        </div>
+      </details>
+    }
+  }
+
+  <div className="bg-white rounded-xl border border-slate-200 shadow-sm p-6">
+    <div className="mb-6">
+      <h3 className="text-lg font-medium text-slate-900 mb-2"> {"Results"->React.string} </h3>
+      <p className="text-sm text-slate-600">
+        {"View your Solana query structure and results"->React.string}
+      </p>
+      <div className="mt-3">
+        <span
+          className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-slate-100 text-slate-700 border border-slate-200">
+          {`Query URL: ${solanaEndpoint}`->React.string}
+        </span>
+      </div>
+    </div>
+
+    <div
+      className="border-b border-slate-200 sticky top-[56px] bg-white/80 backdrop-blur z-10 -mx-6 px-6 mb-6">
+      <nav className="flex space-x-8">
+        <button
+          onClick={_ => setActiveTab(_ => QueryJson)}
+          className={`py-3 px-1 border-b-2 font-medium text-sm transition-colors ${activeTab ===
+              QueryJson
+              ? "border-slate-900 text-slate-900"
+              : "border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300"}`}>
+          {"Query JSON"->React.string}
+        </button>
+        <button
+          onClick={_ => setActiveTab(_ => Results)}
+          className={`py-3 px-1 border-b-2 font-medium text-sm transition-colors ${activeTab ===
+              Results
+              ? "border-slate-900 text-slate-900"
+              : "border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300"}`}>
+          {"Results"->React.string}
+        </button>
+      </nav>
+    </div>
+
+    <div className="min-h-96">
+      {switch activeTab {
+      | QueryJson =>
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <h4 className="text-sm font-medium text-slate-900">
+              {"Query Structure"->React.string}
+            </h4>
+            <div className="flex space-x-2">
+              <button
+                onClick={_ => copyCurl()}
+                className={`inline-flex items-center px-3 py-1 text-xs font-medium rounded-lg transition-colors ${copiedCurl
+                    ? "bg-emerald-600 text-white"
+                    : "bg-slate-600 text-white hover:bg-slate-700"}`}>
+                {(copiedCurl ? "Copied!" : "Copy cURL")->React.string}
+              </button>
+              <button
+                onClick={_ => copyJson()}
+                className={`inline-flex items-center px-3 py-1 text-xs font-medium rounded-lg border transition-colors ${copiedJson
+                    ? "bg-emerald-100 text-emerald-700 border-emerald-200"
+                    : "bg-slate-100 text-slate-700 hover:bg-slate-200 border-slate-200"}`}>
+                {(copiedJson ? "Copied!" : "Copy JSON")->React.string}
+              </button>
+              <button
+                onClick={_ => downloadJson()}
+                className="inline-flex items-center px-3 py-1 bg-white text-slate-700 text-xs font-medium rounded-lg hover:bg-slate-50 border border-slate-200 transition-colors">
+                {"Download"->React.string}
+              </button>
+              <button
+                onClick={_ => executeQuery()->ignore}
+                disabled={isExecuting}
+                className="inline-flex items-center px-3 py-1 bg-slate-700 text-white text-xs font-medium rounded-lg hover:bg-slate-800 disabled:opacity-50 transition-colors">
+                {(isExecuting ? "Executing..." : "Execute Query")->React.string}
+              </button>
+            </div>
+          </div>
+          <pre
+            className="bg-slate-50 border border-slate-200 rounded-xl p-4 text-sm font-mono overflow-x-auto whitespace-pre">
+            {serializeQuery(query)->React.string}
+          </pre>
+        </div>
+      | Results =>
+        <div>
+          {switch (queryResult, queryError, isExecuting) {
+          | (_, _, true) =>
+            <div className="text-center py-12">
+              <div className="text-blue-500 mb-4">
+                <svg
+                  className="w-8 h-8 mx-auto animate-spin"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                  />
+                </svg>
+              </div>
+              <h4 className="text-lg font-medium text-blue-600 mb-2">
+                {"Executing Query..."->React.string}
+              </h4>
+            </div>
+          | (Some(result), _, false) =>
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <h4 className="text-sm font-medium text-gray-900"> {"Query Results"->React.string} </h4>
+                <div className="flex items-center">
+                  <span
+                    className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-emerald-100 text-emerald-700 mr-3">
+                    {"Success"->React.string}
+                  </span>
+                  {switch (clientMs, serverMs, responseBytes) {
+                  | (Some(cms), server, bytes) =>
+                    <span className="text-xs text-slate-500 mr-3">
+                      {`${Int.toString(cms)}ms`->React.string}
+                      {switch server {
+                      | Some(sms) => ` · ${Int.toString(sms)}ms server`->React.string
+                      | None => React.null
+                      }}
+                      {switch bytes {
+                      | Some(b) => ` · ${formatBytes(b)}`->React.string
+                      | None => React.null
+                      }}
+                    </span>
+                  | _ => React.null
+                  }}
+                  <button
+                    onClick={_ => copyResultsJson()}
+                    className={`inline-flex items-center px-3 py-1 text-xs font-medium rounded-lg border transition-colors mr-2 ${copiedResults
+                        ? "bg-emerald-100 text-emerald-700 border-emerald-200"
+                        : "bg-white text-slate-700 hover:bg-slate-50 border-slate-200"}`}>
+                    {(copiedResults ? "Copied!" : "Copy Results JSON")->React.string}
+                  </button>
+                  <div className="inline-flex items-center">
+                    <button
+                      onClick={_ => setResultsView(_ => Raw)}
+                      className={`px-3 py-1 text-xs font-medium rounded-l-lg border border-slate-200 ${resultsView ===
+                          Raw
+                          ? "bg-slate-800 text-white"
+                          : "bg-white text-slate-700 hover:bg-slate-50"}`}>
+                      {"Raw"->React.string}
+                    </button>
+                    <button
+                      onClick={_ => setResultsView(_ => Table)}
+                      className={`px-3 py-1 text-xs font-medium rounded-r-lg border border-slate-200 border-l-0 ${resultsView ===
+                          Table
+                          ? "bg-slate-800 text-white"
+                          : "bg-white text-slate-700 hover:bg-slate-50"}`}>
+                      {"Table"->React.string}
+                    </button>
+                  </div>
+                </div>
+              </div>
+              {switch resultsView {
+              | Raw =>
+                switch rawMode {
+                | Plain =>
+                  // Solana responses can be huge (10MB+); cap the inline pre-block
+                  // so the browser does not freeze trying to render millions of chars.
+                  let maxLen = 500_000
+                  let resultLen = String.length(result)
+                  let displayResult = if resultLen > maxLen {
+                    String.substring(result, ~start=0, ~end=maxLen) ++
+                    `\n\n... (truncated, ${Int.toString(resultLen - maxLen)} more chars - use "Copy Results JSON" or switch to Table view)`
+                  } else {
+                    result
+                  }
+                  <div>
+                    <div className="mb-2 flex items-center gap-2">
+                      <button
+                        onClick={_ => setRawMode(_ => Interactive)}
+                        className="px-3 py-1 bg-white text-slate-700 text-xs font-medium rounded-lg hover:bg-slate-50 border border-slate-200 transition-colors">
+                        {"Interactive JSON"->React.string}
+                      </button>
+                      {resultLen > maxLen
+                        ? <span className="text-xs text-amber-700">
+                            {`Response is ${formatBytes(resultLen)} - preview truncated`->React.string}
+                          </span>
+                        : React.null}
+                    </div>
+                    <pre
+                      className="bg-slate-50 border border-slate-200 rounded-xl p-4 text-sm font-mono overflow-x-auto whitespace-pre max-h-96">
+                      {displayResult->React.string}
+                    </pre>
+                  </div>
+                | Interactive =>
+                  <div>
+                    <div className="mb-2">
+                      <button
+                        onClick={_ => setRawMode(_ => Plain)}
+                        className="px-3 py-1 bg-white text-slate-700 text-xs font-medium rounded-lg hover:bg-slate-50 border border-slate-200 transition-colors">
+                        {"Plain JSON"->React.string}
+                      </button>
+                    </div>
+                    <div
+                      className="bg-slate-50 border border-slate-200 rounded-xl p-4 max-h-96 overflow-auto">
+                      {switch queryResultJson {
+                      | Some(json) => renderJsonNode("root", json, 0)
+                      | None => React.null
+                      }}
+                    </div>
+                  </div>
+                }
+              | Table =>
+                switch queryResultJson {
+                | Some(json) => {
+                    let datasetNames = solanaDatasetNames(json)
+                    let effectiveDataset = switch selectedDataset {
+                    | Some(name) => name
+                    | None =>
+                      Array.length(datasetNames) > 0
+                        ? Belt.Array.getExn(datasetNames, 0)
+                        : "blocks"
+                    }
+                    let rowsJson = solanaDatasetRows(json, effectiveDataset)
+                    if Array.length(rowsJson) == 0 {
+                      <div
+                        className="text-sm text-slate-600 bg-slate-50 border border-slate-200 rounded-xl p-4">
+                        {"No tabular rows in this dataset"->React.string}
+                      </div>
+                    } else {
+                      let flatRows = flattenRows(rowsJson)
+                      let columns = detectColumns(flatRows)
+                      let csvText = rowsToCsv(flatRows)
+                      let columnTypes = analyzeColumns(flatRows)
+                      let displayedRows = switch sortColumn {
+                      | Some(col) =>
+                        let colType =
+                          Dict.get(columnTypes, col)->Belt.Option.getWithDefault("text")
+                        sortFlatRows(flatRows, col, colType, sortAscending)
+                      | None => flatRows
+                      }
+                      <div>
+                        <div className="mb-2 flex items-center flex-wrap gap-2">
+                          {Array.length(datasetNames) > 1
+                            ? <div className="inline-flex items-center mr-2">
+                                <span className="text-xs text-slate-500 mr-2">
+                                  {"Dataset"->React.string}
+                                </span>
+                                <div
+                                  className="inline-flex rounded-lg border border-slate-200 overflow-hidden">
+                                  {datasetNames
+                                  ->Array.map(name =>
+                                    <button
+                                      key={name}
+                                      onClick={_ => setSelectedDataset(_ => Some(name))}
+                                      className={`px-3 py-1 text-xs ${name === effectiveDataset
+                                          ? "bg-slate-800 text-white"
+                                          : "bg-white text-slate-700 hover:bg-slate-50"}`}>
+                                      {name->React.string}
+                                    </button>
+                                  )
+                                  ->React.array}
+                                </div>
+                              </div>
+                            : React.null}
+                          <button
+                            onClick={_ => copyText(csvText)}
+                            className="px-3 py-1 bg-slate-100 text-slate-700 text-xs font-medium rounded-lg hover:bg-slate-200 border border-slate-200 transition-colors mr-2">
+                            {"Copy CSV"->React.string}
+                          </button>
+                          <button
+                            onClick={_ => downloadCsv(csvText)}
+                            className="px-3 py-1 bg-white text-slate-700 text-xs font-medium rounded-lg hover:bg-slate-50 border border-slate-200 transition-colors">
+                            {"Download CSV"->React.string}
+                          </button>
+                          <span className="ml-3 text-xs text-slate-500">
+                            {`Showing ${Int.toString(
+                                Array.length(displayedRows),
+                              )} rows`->React.string}
+                          </span>
+                        </div>
+                        <div className="overflow-x-auto max-h-96 rounded-xl border border-slate-200">
+                          <table className="w-full table-fixed border-collapse">
+                            <thead>
+                              <tr>
+                                {columns
+                                ->Array.map(col =>
+                                  <th
+                                    key={col}
+                                    className="px-3 py-2 text-left text-xs font-semibold text-slate-700 sticky top-0 z-10 bg-white border-b border-slate-200"
+                                    style={{width: fixedColumnWidth, maxWidth: fixedColumnWidth}}>
+                                    <button
+                                      className="inline-flex items-center gap-1 hover:underline truncate flex-1 text-left"
+                                      onClick={_ =>
+                                        setSortColumn(prev =>
+                                          if prev === Some(col) {
+                                            setSortAscending(prevAsc => !prevAsc)
+                                            Some(col)
+                                          } else {
+                                            setSortAscending(_ => true)
+                                            Some(col)
+                                          }
+                                        )}
+                                      title={col}>
+                                      <span className="truncate">
+                                        {smartTruncate(col, 20)->React.string}
+                                      </span>
+                                      {switch sortColumn {
+                                      | Some(active) if active === col =>
+                                        <span className="text-slate-400 ml-1">
+                                          {sortAscending
+                                            ? "↑"->React.string
+                                            : "↓"->React.string}
+                                        </span>
+                                      | _ => React.null
+                                      }}
+                                    </button>
+                                  </th>
+                                )
+                                ->React.array}
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {displayedRows
+                              ->Array.mapWithIndex((r, i) =>
+                                <tr
+                                  key={Int.toString(i)}
+                                  className={mod(i, 2) == 1 ? "bg-slate-50" : "bg-white"}>
+                                  {columns
+                                  ->Array.map(col => {
+                                    let v = Dict.get(r, col)->Belt.Option.getWithDefault("")
+                                    <td
+                                      key={col}
+                                      className="px-3 py-2 text-xs text-slate-800 border-b border-slate-200 font-mono"
+                                      style={{
+                                        width: fixedColumnWidth,
+                                        maxWidth: fixedColumnWidth,
+                                      }}>
+                                      <div className="flex items-center gap-2 overflow-hidden">
+                                        <span
+                                          className="truncate flex-1 cursor-default" title={v}>
+                                          {smartTruncate(v, 25)->React.string}
+                                        </span>
+                                      </div>
+                                    </td>
+                                  })
+                                  ->React.array}
+                                </tr>
+                              )
+                              ->React.array}
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    }
+                  }
+                | None =>
+                  <div
+                    className="text-sm text-slate-600 bg-slate-50 border border-slate-200 rounded-xl p-4">
+                    {"No data to display"->React.string}
+                  </div>
+                }
+              }}
+            </div>
+          | (None, Some(error), false) =>
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <h4 className="text-sm font-medium text-gray-900"> {"Query Error"->React.string} </h4>
+                <span
+                  className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                  {"Error"->React.string}
+                </span>
+              </div>
+              <div className="bg-red-50 border border-red-200 rounded-xl p-4 text-sm text-red-700">
+                {error->React.string}
+              </div>
+            </div>
+          | (None, None, false) =>
+            <div className="text-center py-12">
+              <div className="text-slate-400 mb-4">
+                <svg
+                  className="w-12 h-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="1"
+                    d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                  />
+                </svg>
+              </div>
+              <h4 className="text-lg font-medium text-slate-600 mb-2">
+                {"Query Results"->React.string}
+              </h4>
+              <p className="text-slate-500">
+                {"Execute query to see results here..."->React.string}
+              </p>
+              <div className="mt-4 flex justify-center space-x-2">
+                <button
+                  onClick={_ => copyCurl()}
+                  className="px-4 py-2 bg-slate-600 text-white text-sm font-medium rounded-lg hover:bg-slate-700 transition-colors">
+                  {"Copy cURL"->React.string}
+                </button>
+                <button
+                  onClick={_ => executeQuery()->ignore}
+                  className="px-4 py-2 bg-slate-700 text-white text-sm font-medium rounded-lg hover:bg-slate-800 transition-colors">
+                  {"Execute Query"->React.string}
+                </button>
+              </div>
+            </div>
+          }}
+        </div>
+      }}
+    </div>
+  </div>
+}

--- a/src/SolanaQueryStructure.res
+++ b/src/SolanaQueryStructure.res
@@ -1,0 +1,286 @@
+// Solana HyperSync data model
+// Schema differs from EVM: uses from_slot/to_slot, "fields" instead of "field_selection",
+// no join_mode (joins are per-selection via include_* booleans), and 7 response tables.
+
+// Selection (filter) types
+
+type instructionSelection = {
+  programId: option<array<string>>,
+  d1: option<array<string>>,
+  d2: option<array<string>>,
+  d4: option<array<string>>,
+  d8: option<array<string>>,
+  a0: option<array<string>>,
+  a1: option<array<string>>,
+  a2: option<array<string>>,
+  a3: option<array<string>>,
+  a4: option<array<string>>,
+  a5: option<array<string>>,
+  a6: option<array<string>>,
+  a7: option<array<string>>,
+  a8: option<array<string>>,
+  a9: option<array<string>>,
+  isInner: option<bool>,
+  includeTransaction: bool,
+  includeLogs: bool,
+}
+
+let emptyInstructionSelection: instructionSelection = {
+  programId: None,
+  d1: None,
+  d2: None,
+  d4: None,
+  d8: None,
+  a0: None,
+  a1: None,
+  a2: None,
+  a3: None,
+  a4: None,
+  a5: None,
+  a6: None,
+  a7: None,
+  a8: None,
+  a9: None,
+  isInner: None,
+  includeTransaction: false,
+  includeLogs: false,
+}
+
+type transactionSelection = {
+  feePayer: option<array<string>>,
+  success: option<bool>,
+  includeInstructions: bool,
+}
+
+let emptyTransactionSelection: transactionSelection = {
+  feePayer: None,
+  success: None,
+  includeInstructions: false,
+}
+
+type logSelection = {
+  programId: option<array<string>>,
+  kind: option<array<string>>,
+  includeTransaction: bool,
+  includeInstruction: bool,
+}
+
+let emptyLogSelection: logSelection = {
+  programId: None,
+  kind: None,
+  includeTransaction: false,
+  includeInstruction: false,
+}
+
+// Field selection enums (snake_case wire names via @as)
+
+type blockField =
+  | @as("slot") Slot
+  | @as("blockhash") Blockhash
+  | @as("parent_slot") ParentSlot
+  | @as("parent_blockhash") ParentBlockhash
+  | @as("block_time") BlockTime
+  | @as("block_height") BlockHeight
+
+let allBlockFields: array<blockField> = [
+  Slot,
+  Blockhash,
+  ParentSlot,
+  ParentBlockhash,
+  BlockTime,
+  BlockHeight,
+]
+
+type transactionField =
+  | @as("slot") Slot
+  | @as("transaction_index") TransactionIndex
+  | @as("signatures") Signatures
+  | @as("fee_payer") FeePayer
+  | @as("success") Success
+  | @as("err") Err
+  | @as("fee") Fee
+  | @as("compute_units_consumed") ComputeUnitsConsumed
+  | @as("account_keys") AccountKeys
+  | @as("recent_blockhash") RecentBlockhash
+  | @as("version") Version
+  | @as("loaded_addresses_writable") LoadedAddressesWritable
+  | @as("loaded_addresses_readonly") LoadedAddressesReadonly
+
+let allTransactionFields: array<transactionField> = [
+  Slot,
+  TransactionIndex,
+  Signatures,
+  FeePayer,
+  Success,
+  Err,
+  Fee,
+  ComputeUnitsConsumed,
+  AccountKeys,
+  RecentBlockhash,
+  Version,
+  LoadedAddressesWritable,
+  LoadedAddressesReadonly,
+]
+
+type instructionField =
+  | @as("slot") Slot
+  | @as("transaction_index") TransactionIndex
+  | @as("instruction_address") InstructionAddress
+  | @as("program_id") ProgramId
+  | @as("accounts") Accounts
+  | @as("data") Data
+  | @as("d1") D1
+  | @as("d2") D2
+  | @as("d4") D4
+  | @as("d8") D8
+  | @as("a0") A0
+  | @as("a1") A1
+  | @as("a2") A2
+  | @as("a3") A3
+  | @as("a4") A4
+  | @as("a5") A5
+  | @as("a6") A6
+  | @as("a7") A7
+  | @as("a8") A8
+  | @as("a9") A9
+  | @as("is_inner") IsInner
+  | @as("is_committed") IsCommitted
+
+let allInstructionFields: array<instructionField> = [
+  Slot,
+  TransactionIndex,
+  InstructionAddress,
+  ProgramId,
+  Accounts,
+  Data,
+  D1,
+  D2,
+  D4,
+  D8,
+  A0,
+  A1,
+  A2,
+  A3,
+  A4,
+  A5,
+  A6,
+  A7,
+  A8,
+  A9,
+  IsInner,
+  IsCommitted,
+]
+
+type logField =
+  | @as("slot") Slot
+  | @as("transaction_index") TransactionIndex
+  | @as("instruction_address") InstructionAddress
+  | @as("program_id") ProgramId
+  | @as("kind") Kind
+  | @as("message") Message
+
+let allLogFields: array<logField> = [
+  Slot,
+  TransactionIndex,
+  InstructionAddress,
+  ProgramId,
+  Kind,
+  Message,
+]
+
+type balanceField =
+  | @as("slot") Slot
+  | @as("transaction_index") TransactionIndex
+  | @as("account") Account
+  | @as("pre") Pre
+  | @as("post") Post
+
+let allBalanceFields: array<balanceField> = [Slot, TransactionIndex, Account, Pre, Post]
+
+type tokenBalanceField =
+  | @as("slot") Slot
+  | @as("transaction_index") TransactionIndex
+  | @as("account") Account
+  | @as("mint") Mint
+  | @as("owner") Owner
+  | @as("pre_amount") PreAmount
+  | @as("post_amount") PostAmount
+
+let allTokenBalanceFields: array<tokenBalanceField> = [
+  Slot,
+  TransactionIndex,
+  Account,
+  Mint,
+  Owner,
+  PreAmount,
+  PostAmount,
+]
+
+type rewardField =
+  | @as("slot") Slot
+  | @as("pubkey") Pubkey
+  | @as("lamports") Lamports
+  | @as("post_balance") PostBalance
+  | @as("reward_type") RewardType
+  | @as("commission") Commission
+
+let allRewardFields: array<rewardField> = [
+  Slot,
+  Pubkey,
+  Lamports,
+  PostBalance,
+  RewardType,
+  Commission,
+]
+
+type fieldSelection = {
+  block: array<blockField>,
+  transaction: array<transactionField>,
+  instruction: array<instructionField>,
+  log: array<logField>,
+  balance: array<balanceField>,
+  tokenBalance: array<tokenBalanceField>,
+  reward: array<rewardField>,
+}
+
+let emptyFieldSelection: fieldSelection = {
+  block: [],
+  transaction: [],
+  instruction: [],
+  log: [],
+  balance: [],
+  tokenBalance: [],
+  reward: [],
+}
+
+type query = {
+  fromSlot: int,
+  toSlot: option<int>,
+  instructions: option<array<instructionSelection>>,
+  transactions: option<array<transactionSelection>>,
+  logs: option<array<logSelection>>,
+  includeAllBlocks: option<bool>,
+  fields: fieldSelection,
+  maxNumBlocks: option<int>,
+  maxNumTransactions: option<int>,
+  maxNumInstructions: option<int>,
+  maxNumLogs: option<int>,
+}
+
+// Snake-case stringifiers (relies on @as mapping; Obj.magic returns the wire string)
+let blockFieldToSnake = (f: blockField): string => Obj.magic(f)
+let transactionFieldToSnake = (f: transactionField): string => Obj.magic(f)
+let instructionFieldToSnake = (f: instructionField): string => Obj.magic(f)
+let logFieldToSnake = (f: logField): string => Obj.magic(f)
+let balanceFieldToSnake = (f: balanceField): string => Obj.magic(f)
+let tokenBalanceFieldToSnake = (f: tokenBalanceField): string => Obj.magic(f)
+let rewardFieldToSnake = (f: rewardField): string => Obj.magic(f)
+
+let snakeToTitle = (input: string): string =>
+  Js.String.split("_", input)
+  ->Belt.Array.keep(s => s != "")
+  ->Belt.Array.map(s =>
+    String.toUpperCase(Js.String.slice(~from=0, ~to_=1, s)) ++
+    Js.String.slice(~from=1, ~to_=String.length(s), s)
+  )
+  ->Array.join(" ")

--- a/src/SolanaTransactionFilter.res
+++ b/src/SolanaTransactionFilter.res
@@ -1,0 +1,177 @@
+open SolanaQueryStructure
+
+type filterState = SolanaQueryStructure.transactionSelection
+
+let labelClass = "block text-xs font-medium text-slate-700 mb-1"
+let inputClass = "flex-1 border border-slate-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-colors"
+let addBtnClass = "px-3 py-2 bg-slate-700 text-white text-xs font-medium rounded-lg hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 disabled:opacity-50 transition-colors"
+let chipClass = "flex items-center justify-between bg-slate-50 px-3 py-1.5 rounded-lg border border-slate-100"
+
+let isBase58Pubkey = SolanaInstructionFilter.isBase58Pubkey
+
+@react.component
+let make = (
+  ~filterState: filterState,
+  ~onFilterChange: filterState => unit,
+  ~onRemove: unit => unit,
+  ~filterIndex: int,
+  ~isExpanded: bool,
+  ~onToggleExpand: unit => unit,
+) => {
+  let (newFeePayer, setNewFeePayer) = React.useState(() => "")
+
+  let updateField = (newState: filterState) => onFilterChange(newState)
+
+  let addFeePayer = (v: string) => {
+    if isBase58Pubkey(v) {
+      updateField({
+        ...filterState,
+        feePayer: Some(Array.concat(filterState.feePayer->Option.getOr([]), [v])),
+      })
+      setNewFeePayer(_ => "")
+    }
+  }
+
+  let removeFeePayer = (idx: int) => {
+    let cur = filterState.feePayer->Option.getOr([])
+    let next = Belt.Array.keepWithIndex(cur, (_, i) => i !== idx)
+    updateField({...filterState, feePayer: Array.length(next) > 0 ? Some(next) : None})
+  }
+
+  let hasFilters = Option.isSome(filterState.feePayer) || Option.isSome(filterState.success)
+
+  <div
+    className="relative bg-white rounded-xl border border-slate-200 shadow-sm transition-all w-full">
+    <div className="p-4 border-b border-slate-100">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <h3 className="text-lg font-medium text-slate-900">
+            {`Transaction Filter ${Int.toString(filterIndex + 1)}`->React.string}
+          </h3>
+          {hasFilters
+            ? <span
+                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700">
+                {"Active"->React.string}
+              </span>
+            : React.null}
+        </div>
+        <div className="flex items-center space-x-1">
+          <button
+            onClick={_ => onToggleExpand()}
+            className="inline-flex items-center p-2 text-sm font-medium text-slate-500 hover:text-slate-700 hover:bg-slate-50 rounded-lg transition-colors">
+            <svg
+              className={`w-4 h-4 transform transition-transform ${isExpanded
+                  ? "rotate-180"
+                  : "rotate-0"}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+          <button
+            onClick={_ => onRemove()}
+            className="inline-flex items-center p-2 text-sm font-medium text-red-500 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    {isExpanded
+      ? <div className="p-6">
+          // Fee payer
+          <div className="mb-4">
+            <label className={labelClass}> {"Fee Payer Pubkeys (base58)"->React.string} </label>
+            <div className="flex space-x-2 mb-2">
+              <input
+                type_="text"
+                value={newFeePayer}
+                onChange={e => {
+                  let target = ReactEvent.Form.target(e)
+                  setNewFeePayer(_ => target["value"])
+                }}
+                onKeyDown={e =>
+                  if ReactEvent.Keyboard.key(e) === "Enter" {
+                    ReactEvent.Synthetic.preventDefault(e)
+                    addFeePayer(newFeePayer)
+                  }}
+                placeholder="base58 pubkey"
+                className={inputClass}
+              />
+              <button
+                onClick={_ => addFeePayer(newFeePayer)}
+                disabled={String.length(newFeePayer) === 0 || !isBase58Pubkey(newFeePayer)}
+                className={addBtnClass}>
+                {(
+                  Array.length(filterState.feePayer->Option.getOr([])) > 0 ? "Add (OR)" : "Add"
+                )->React.string}
+              </button>
+            </div>
+            <div className="space-y-1">
+              {filterState.feePayer
+              ->Option.getOr([])
+              ->Array.mapWithIndex((v, i) =>
+                <div key={Int.toString(i)} className={chipClass}>
+                  <span className="text-xs font-mono text-slate-800 truncate">
+                    {v->React.string}
+                  </span>
+                  <button
+                    onClick={_ => removeFeePayer(i)}
+                    className="ml-2 text-red-600 hover:text-red-800 text-xs font-medium transition-colors">
+                    {"Remove"->React.string}
+                  </button>
+                </div>
+              )
+              ->React.array}
+            </div>
+          </div>
+
+          // Success toggle
+          <div className="mb-4">
+            <label className={labelClass}> {"Success"->React.string} </label>
+            <div className="flex space-x-2">
+              {[("Either", None), ("Success only", Some(true)), ("Failed only", Some(false))]
+              ->Array.map(((label, value)) => {
+                let isActive = filterState.success === value
+                <button
+                  key={label}
+                  onClick={_ => updateField({...filterState, success: value})}
+                  className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-colors ${isActive
+                      ? "bg-slate-800 text-white border-slate-800"
+                      : "bg-white text-slate-700 border-slate-200 hover:bg-slate-50"}`}>
+                  {label->React.string}
+                </button>
+              })
+              ->React.array}
+            </div>
+          </div>
+
+          // Joins
+          <div>
+            <label className={labelClass}> {"Joins"->React.string} </label>
+            <label className="inline-flex items-center text-xs text-slate-700 cursor-pointer">
+              <input
+                type_="checkbox"
+                checked={filterState.includeInstructions}
+                onChange={e => {
+                  let target = ReactEvent.Form.target(e)
+                  updateField({...filterState, includeInstructions: target["checked"]})
+                }}
+                className="mr-2"
+              />
+              {"include_instructions"->React.string}
+            </label>
+          </div>
+        </div>
+      : React.null}
+  </div>
+}


### PR DESCRIPTION
## Summary

- Adds a Solana ecosystem alongside the existing EVM builder, accessible via an EVM/Solana toggle in the header (URL hash `#solana`).
- Posts to `https://solana-near-head-test.hypersync.xyz/query`, fetches the live head from `/height` for sensible default slot values.
- Ships an experimental notice mentioning Discord and the planned historical-range expansion.

## Notes on the schema (differs from EVM)

- `from_slot`/`to_slot` instead of `from_block`/`to_block`
- top-level key is `fields` instead of `field_selection`
- three filter types (`instructions`, `transactions`, `logs`) instead of four
- per-selection `include_*` joins instead of `join_mode`
- field selection covers seven tables: `block`, `transaction`, `instruction`, `log`, `balance`, `token_balance`, `reward`

## Solana-native filter primitives

Instruction filter exposes: `program_id` (base58), hex discriminators `d1`/`d2`/`d4`/`d8`, account-position filters `a0`..`a9`, `is_inner` (CPI vs outer), and `include_transaction`/`include_logs`. Transaction filter has `fee_payer`, `success`, `include_instructions`. Log filter has `program_id`, `kind`, `include_transaction`, `include_instruction`.

## UX considerations

- Defaults to Table view (Solana responses are typically MB-sized due to auto-attached balance/token_balance rows).
- Inline raw JSON `<pre>` is capped at 500KB so a multi-MB response can't freeze the page.
- The dataset switcher only shows tables that actually returned rows.
- Three quick-start presets: `SPL Token Transfers`, `System Program SOL Transfers`, `All Blocks` (kept to small slot ranges so previews stay snappy).

## Test plan

- [ ] Visit `/` - existing EVM builder still works, new EVM/Solana toggle is in the header.
- [ ] Click `Solana BETA` - experimental banner appears with Discord link.
- [ ] Live head slot is shown next to the network card.
- [ ] Click `All Blocks` preset, then `Execute Query` - results land on Table view with dataset switcher (`blocks`/`balances`/`token_balances`/`rewards`).
- [ ] Sort columns and Copy/Download CSV.
- [ ] Click `+ Instruction Filter`, fill program_id + d1 + toggle joins, execute.
- [ ] `Query JSON` tab shows correct body with `from_slot`, `fields`, `instructions[]`.
- [ ] Switch back to `EVM` toggle - existing builder unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-ecosystem support to switch between EVM and Solana networks
  * Introduced Solana query builder with configurable filters for instructions, transactions, and logs
  * Added field selection for Solana data
  * Implemented query results with multiple views and export options (JSON, CSV)
  * Enhanced header with ecosystem controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->