### PR TITLE
feat(solana): expand quick-start templates

### DIFF
--- a/src/SolanaApp.res
+++ b/src/SolanaApp.res
@@ -5,6 +5,25 @@ let tokenProgramId = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 let token2022ProgramId = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
 let systemProgramId = "11111111111111111111111111111111"
 let computeBudgetProgramId = "ComputeBudget111111111111111111111111111111"
+let orcaWhirlpoolProgramId = "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc"
+let jupiterV6ProgramId = "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"
+
+// Anchor 8-byte discriminator for Whirlpool's `swap` instruction
+let whirlpoolSwapD8 = "0xf8c69e91e17587c8"
+
+// Demo fee payer used when the user has not entered one
+let demoFeePayer = "MfDuWeqSHEqTFVYZ7LoexgAK9dxk7cy4DFJWjWMGVWa"
+
+// Looks like a base58 Solana pubkey (32-44 base58 chars)
+let looksLikePubkey = (s: string): bool => {
+  let len = String.length(s)
+  if len < 32 || len > 44 {
+    false
+  } else {
+    let re = RegExp.fromString("^[1-9A-HJ-NP-Za-km-z]+$")
+    RegExp.test(re, s)
+  }
+}
 
 @react.component
 let make = (
@@ -29,6 +48,7 @@ let make = (
   let (expandedFilterKey, setExpandedFilterKey) = React.useState(() => None)
   let (executeSignal, setExecuteSignal) = React.useState(() => 0)
   let (currentHead, setCurrentHead) = React.useState(() => None)
+  let (quickStartFeePayer, setQuickStartFeePayer) = React.useState(() => "")
 
   // Fetch current head on mount so users can pick a sensible from_slot
   React.useEffect0(() => {
@@ -59,6 +79,7 @@ let make = (
 
   let resetBuilder = () => {
     setExpandedFilterKey(_ => None)
+    setQuickStartFeePayer(_ => "")
     setQuery(_ => defaultQuery())
   }
 
@@ -227,6 +248,215 @@ let make = (
       },
       maxNumBlocks: Some(2),
     })
+  }
+
+  // Token-2022 transfers - same d1 byte as classic SPL Token, but a different program ID.
+  // Useful for showing devs the modern alternative to TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA.
+  let applyPresetToken2022Transfers = () => {
+    let from = switch currentHead {
+    | Some(h) => h - 5
+    | None => 0
+    }
+    setQuery(_ => {
+      ...defaultQuery(),
+      fromSlot: from,
+      toSlot: Some(from + 5),
+      instructions: Some([
+        {
+          ...emptyInstructionSelection,
+          programId: Some([token2022ProgramId]),
+          d1: Some(["0x03"]),
+          includeTransaction: true,
+        },
+      ]),
+      fields: {
+        ...emptyFieldSelection,
+        block: [Slot, Blockhash, BlockTime],
+        transaction: [Slot, TransactionIndex, Signatures, FeePayer, Success, Fee],
+        instruction: [Slot, TransactionIndex, ProgramId, Data, A0, A1, A2, D1],
+      },
+      maxNumBlocks: Some(5),
+      maxNumTransactions: Some(50),
+      maxNumInstructions: Some(100),
+    })
+    setExpandedFilterKey(_ => Some("instruction-0"))
+  }
+
+  // Orca Whirlpool swaps - Anchor program filtered by its 8-byte swap discriminator.
+  let applyPresetWhirlpoolSwaps = () => {
+    let from = switch currentHead {
+    | Some(h) => h - 5
+    | None => 0
+    }
+    setQuery(_ => {
+      ...defaultQuery(),
+      fromSlot: from,
+      toSlot: Some(from + 5),
+      instructions: Some([
+        {
+          ...emptyInstructionSelection,
+          programId: Some([orcaWhirlpoolProgramId]),
+          d8: Some([whirlpoolSwapD8]),
+          includeTransaction: true,
+        },
+      ]),
+      fields: {
+        ...emptyFieldSelection,
+        block: [Slot, Blockhash, BlockTime],
+        transaction: [Slot, TransactionIndex, Signatures, FeePayer, Success, Err, Fee],
+        instruction: [
+          Slot,
+          TransactionIndex,
+          InstructionAddress,
+          ProgramId,
+          Accounts,
+          Data,
+          D8,
+          IsInner,
+        ],
+      },
+      maxNumBlocks: Some(5),
+      maxNumTransactions: Some(50),
+      maxNumInstructions: Some(100),
+    })
+    setExpandedFilterKey(_ => Some("instruction-0"))
+  }
+
+  // Multi-DEX OR - two separate instructions[] entries combine with OR semantics.
+  // Each entry has only program_id set, so any ix from either Jupiter v6 or Whirlpool matches.
+  let applyPresetJupiterOrOrca = () => {
+    let from = switch currentHead {
+    | Some(h) => h - 3
+    | None => 0
+    }
+    setQuery(_ => {
+      ...defaultQuery(),
+      fromSlot: from,
+      toSlot: Some(from + 3),
+      instructions: Some([
+        {
+          ...emptyInstructionSelection,
+          programId: Some([jupiterV6ProgramId]),
+          includeTransaction: true,
+        },
+        {
+          ...emptyInstructionSelection,
+          programId: Some([orcaWhirlpoolProgramId]),
+          includeTransaction: true,
+        },
+      ]),
+      fields: {
+        ...emptyFieldSelection,
+        block: [Slot, Blockhash, BlockTime],
+        transaction: [Slot, TransactionIndex, Signatures, FeePayer, Success, Fee],
+        instruction: [
+          Slot,
+          TransactionIndex,
+          InstructionAddress,
+          ProgramId,
+          Data,
+          D8,
+          IsInner,
+        ],
+      },
+      maxNumBlocks: Some(3),
+      maxNumTransactions: Some(50),
+      maxNumInstructions: Some(150),
+    })
+    setExpandedFilterKey(_ => Some("instruction-0"))
+  }
+
+  // Failed transactions - transaction-side filter using success: false.
+  // include_instructions pulls in every ix from each failed tx for inspection.
+  let applyPresetFailedTransactions = () => {
+    let from = switch currentHead {
+    | Some(h) => h - 3
+    | None => 0
+    }
+    setQuery(_ => {
+      ...defaultQuery(),
+      fromSlot: from,
+      toSlot: Some(from + 3),
+      transactions: Some([
+        {
+          ...emptyTransactionSelection,
+          success: Some(false),
+          includeInstructions: true,
+        },
+      ]),
+      fields: {
+        ...emptyFieldSelection,
+        block: [Slot, Blockhash, BlockTime],
+        transaction: [
+          Slot,
+          TransactionIndex,
+          Signatures,
+          FeePayer,
+          Success,
+          Err,
+          Fee,
+          ComputeUnitsConsumed,
+        ],
+        instruction: [Slot, TransactionIndex, ProgramId, Data],
+      },
+      maxNumBlocks: Some(3),
+      maxNumTransactions: Some(50),
+      maxNumInstructions: Some(200),
+    })
+    setExpandedFilterKey(_ => Some("transaction-0"))
+  }
+
+  // Transactions by fee payer - inverse direction. Filter on the transactions table,
+  // then pull all ix that belong to those txs via include_instructions.
+  let applyPresetTxnsByFeePayer = () => {
+    let from = switch currentHead {
+    | Some(h) => h - 50
+    | None => 0
+    }
+    let payer = if looksLikePubkey(quickStartFeePayer) {
+      quickStartFeePayer
+    } else {
+      demoFeePayer
+    }
+    setQuery(_ => {
+      ...defaultQuery(),
+      fromSlot: from,
+      toSlot: Some(from + 50),
+      transactions: Some([
+        {
+          ...emptyTransactionSelection,
+          feePayer: Some([payer]),
+          includeInstructions: true,
+        },
+      ]),
+      fields: {
+        ...emptyFieldSelection,
+        block: [Slot, Blockhash, BlockTime],
+        transaction: [
+          Slot,
+          TransactionIndex,
+          Signatures,
+          FeePayer,
+          Success,
+          Err,
+          Fee,
+          ComputeUnitsConsumed,
+        ],
+        instruction: [
+          Slot,
+          TransactionIndex,
+          InstructionAddress,
+          ProgramId,
+          Accounts,
+          Data,
+          D8,
+        ],
+      },
+      maxNumBlocks: Some(50),
+      maxNumTransactions: Some(50),
+      maxNumInstructions: Some(500),
+    })
+    setExpandedFilterKey(_ => Some("transaction-0"))
   }
 
   let totalFilters =
@@ -436,22 +666,76 @@ let make = (
                       {"Quick start"->React.string}
                     </h4>
                     <p className="text-xs text-slate-600">
-                      {"Start from a popular Solana template"->React.string}
+                      {"Start from a popular Solana template - each one teaches a different filter pattern"->React.string}
                     </p>
+                  </div>
+                  <div className="mb-3 flex items-center gap-2">
+                    <input
+                      type_="text"
+                      value={quickStartFeePayer}
+                      onChange={e => {
+                        let target = ReactEvent.Form.target(e)
+                        setQuickStartFeePayer(_ => target["value"])
+                      }}
+                      placeholder="Fee payer pubkey for the 'Txns by Fee Payer' preset (base58)"
+                      className="flex-1 border border-slate-300 rounded-lg px-3 py-1.5 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-colors"
+                    />
+                    <span className="text-[11px] text-slate-500">
+                      {if String.length(quickStartFeePayer) === 0 {
+                        "Defaults to a demo address"
+                      } else if looksLikePubkey(quickStartFeePayer) {
+                        "Looks valid"
+                      } else {
+                        "Not a valid base58 pubkey"
+                      }->React.string}
+                    </span>
                   </div>
                   <div className="flex flex-wrap gap-2">
                     <button
                       onClick={_ => applyPresetSplTokenTransfers()}
+                      title="SPL Token Transfer ix - filtered by program_id and the 1-byte d1 discriminator"
                       className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
-                      {"SPL Token Transfers"->React.string}
+                      {"SPL Token Transfers (d1)"->React.string}
+                    </button>
+                    <button
+                      onClick={_ => applyPresetToken2022Transfers()}
+                      title="Token-2022 Transfer ix - same d1 byte, different program ID"
+                      className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
+                      {"Token-2022 Transfers (d1)"->React.string}
                     </button>
                     <button
                       onClick={_ => applyPresetSystemTransfers()}
+                      title="System Program transfer (lamports) - native programs use 4-byte LE u32 indices"
                       className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
-                      {"System Program SOL Transfers"->React.string}
+                      {"System SOL Transfers (d4)"->React.string}
+                    </button>
+                    <button
+                      onClick={_ => applyPresetWhirlpoolSwaps()}
+                      title="Orca Whirlpool swap - Anchor programs use 8-byte hash discriminators"
+                      className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
+                      {"Whirlpool Swaps (d8 Anchor)"->React.string}
+                    </button>
+                    <button
+                      onClick={_ => applyPresetJupiterOrOrca()}
+                      title="Two entries in the instructions[] array combine with OR semantics"
+                      className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
+                      {"Jupiter OR Orca (multi-filter OR)"->React.string}
+                    </button>
+                    <button
+                      onClick={_ => applyPresetFailedTransactions()}
+                      title="Filter on the transactions table by success: false, then pull each failed tx's ix via include_instructions"
+                      className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
+                      {"Failed Transactions"->React.string}
+                    </button>
+                    <button
+                      onClick={_ => applyPresetTxnsByFeePayer()}
+                      title="Inverse direction - filter txs by fee_payer, include_instructions pulls the ix"
+                      className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
+                      {"Txns by Fee Payer"->React.string}
                     </button>
                     <button
                       onClick={_ => applyPresetAllBlocks()}
+                      title="include_all_blocks: true - returns every block in the slot range"
                       className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 transition-colors">
                       {"All Blocks"->React.string}
                     </button>


### PR DESCRIPTION
## Summary

Adds 5 new Solana quick-start templates (8 total) and a fee-payer input field. Each template is designed to teach a specific filter pattern from the Solana HyperSync schema.

## What's new

| Template | Teaches |
| --- | --- |
| **SPL Token Transfers (d1)** | 1-byte discriminator on the SPL Token program (existing, label refreshed) |
| **Token-2022 Transfers (d1)** | Same d1 byte, different program ID (modern alternative) |
| **System SOL Transfers (d4)** | 4-byte LE u32 discriminator used by native programs (existing, label refreshed) |
| **Whirlpool Swaps (d8 Anchor)** | 8-byte hash discriminator used by Anchor programs |
| **Jupiter OR Orca (multi-filter OR)** | Two entries in `instructions[]` combine with OR semantics |
| **Failed Transactions** | Transaction-side filter (`success: false`) + `include_instructions` to inspect each failed tx |
| **Txns by Fee Payer** | Inverse direction - filter txs by `fee_payer`, joins ix back via `include_instructions`. Uses a Quick Start input pubkey, falls back to a demo address |
| **All Blocks** | `include_all_blocks: true` (existing) |

Each button has a `title` tooltip explaining what the template teaches.

## Notes

- Slot ranges and `max_num_*` limits on each preset are kept small so previews stay responsive against the near-head test endpoint.
- The new fee-payer input validates as base58 (32-44 chars), with live "Looks valid"/"Not a valid base58 pubkey" feedback.
- No schema changes - all new templates use the data model from #25.

## Test plan

- [ ] Click each new preset, confirm the `Query JSON` matches the educational intent (correct program_id, discriminator key, filter side).
- [ ] Click `Failed Transactions` then `Execute Query` - results show transactions with non-null `err`.
- [ ] Click `Whirlpool Swaps (d8 Anchor)`, confirm `instructions[0].program_id` is the Whirlpool ID and `d8` is `0xf8c69e91e17587c8`.
- [ ] Click `Jupiter OR Orca`, confirm `instructions[]` has two entries (OR semantics).
- [ ] Type a base58 pubkey into the fee-payer input, click `Txns by Fee Payer`, confirm the typed value appears in the JSON.
- [ ] Leave the input empty, click `Txns by Fee Payer`, confirm the demo address is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new preset query templates for Token-2022 transfers, Whirlpool swaps, Jupiter/Orca swaps, failed transactions, and transactions by fee payer.
  * Introduced fee payer input field in quick start with validation support.
  * Enhanced quick start interface with improved descriptions and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->