### PR TITLE
feat: support exclude filters across the query builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Live at [builder.hypersync.xyz](https://builder.hypersync.xyz).
 - **Visual query building**: Construct HyperSync queries through a UI instead of writing JSON by hand
 - **Multi-chain support**: Select from all networks supported by HyperSync
 - **Log, transaction, and block filtering**: Configure filters for any combination of data types
+- **Exclude filters**: Add per-filter exclusions (e.g. all Transfer events except from certain addresses), explained in plain English and in the boolean logic view
 - **Field selection**: Choose exactly which fields to return in your queries
 - **Query export**: Generate ready-to-use cURL commands and JSON queries to copy into your code
 - **Real-time execution**: Run queries directly from the UI and inspect the response

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "build:site": "npm run res:build && vite build",
     "build:dev": "vite build",
     "preview": "vite preview",
-    "test": "cp rescript.json rescript.json.bak && cp rescript.test.json rescript.json && rescript build --dev && retest tests/**/*.res.mjs; RESULT=$?; cp rescript.json.bak rescript.json && rm rescript.json.bak; exit $RESULT",
+    "test": "cp rescript.json rescript.json.bak && cp rescript.test.json rescript.json && rescript build --dev && retest tests/*.res.mjs tests/**/*.res.mjs; RESULT=$?; cp rescript.json.bak rescript.json && rm rescript.json.bak; exit $RESULT",
     "update-chains": "node scripts/update-chains.mjs",
     "prepublishOnly": "npm run build:package"
   },

--- a/src/BlockBooleanLogicGenerator.res
+++ b/src/BlockBooleanLogicGenerator.res
@@ -1,48 +1,68 @@
 type blockFilterState = QueryStructure.blockSelection
 
-let generateEnglishDescription = (filterState: blockFilterState) => {
+// True when the filter's own fields are empty, ignoring any exclude filter.
+let isEmptyBlockFields = (filterState: blockFilterState) => {
+  let {hash, miner} = filterState
+  Array.length(hash->Option.getOr([])) === 0 && Array.length(miner->Option.getOr([])) === 0
+}
+
+// Returns the exclude filter only when it actually has conditions.
+let excludeContent = (filterState: blockFilterState): option<blockFilterState> =>
+  switch filterState.exclude {
+  | Some(ex) if !isEmptyBlockFields(ex) => Some(ex)
+  | _ => None
+  }
+
+// Description of the filter's own fields, "" when empty.
+let generateFieldsDescription = (filterState: blockFilterState) => {
   let {hash, miner} = filterState
   let hashArray = hash->Option.getOr([])
   let minerArray = miner->Option.getOr([])
 
-  let hasAnyFilter = Array.length(hashArray) > 0 || Array.length(minerArray) > 0
+  let parts = []
 
-  if !hasAnyFilter {
-    "No filters applied - will match all blocks"
-  } else {
-    let parts = []
-
-    // Hash condition
-    if Array.length(hashArray) > 0 {
-      let hashCondition = if Array.length(hashArray) === 1 {
-        `the block hash is ${Array.getUnsafe(hashArray, 0)}`
-      } else {
-        let hashList = Array.join(hashArray, " OR ")
-        `the block hash is ${hashList}`
-      }
-      parts->Array.push(hashCondition)->ignore
-    }
-
-    // Miner condition
-    if Array.length(minerArray) > 0 {
-      let minerCondition = if Array.length(minerArray) === 1 {
-        `the miner address is ${Array.getUnsafe(minerArray, 0)}`
-      } else {
-        let minerList = Array.join(minerArray, " OR ")
-        `the miner address is ${minerList}`
-      }
-      parts->Array.push(minerCondition)->ignore
-    }
-
-    if Array.length(parts) > 0 {
-      `Match blocks where: ${Array.join(parts, " AND ")}`
+  // Hash condition
+  if Array.length(hashArray) > 0 {
+    let hashCondition = if Array.length(hashArray) === 1 {
+      `the block hash is ${Array.getUnsafe(hashArray, 0)}`
     } else {
+      let hashList = Array.join(hashArray, " OR ")
+      `the block hash is ${hashList}`
+    }
+    parts->Array.push(hashCondition)->ignore
+  }
+
+  // Miner condition
+  if Array.length(minerArray) > 0 {
+    let minerCondition = if Array.length(minerArray) === 1 {
+      `the miner address is ${Array.getUnsafe(minerArray, 0)}`
+    } else {
+      let minerList = Array.join(minerArray, " OR ")
+      `the miner address is ${minerList}`
+    }
+    parts->Array.push(minerCondition)->ignore
+  }
+
+  Array.join(parts, " AND ")
+}
+
+let generateEnglishDescription = (filterState: blockFilterState) => {
+  let include_ = generateFieldsDescription(filterState)
+  switch excludeContent(filterState) {
+  | Some(ex) =>
+    let exclude = generateFieldsDescription(ex)
+    `Match blocks where: ${BooleanLogicFormat.composeDescriptionWithNot(~include_, ~exclude)}`
+  | None =>
+    if include_ === "" {
       "No filters applied - will match all blocks"
+    } else {
+      `Match blocks where: ${include_}`
     }
   }
 }
 
-let generateBooleanHierarchy = (filterState: blockFilterState) => {
+// Hierarchy of the filter's own fields, ignoring any exclude filter.
+let generateFieldsHierarchy = (filterState: blockFilterState) => {
   let {hash, miner} = filterState
   let hashArray = hash->Option.getOr([])
   let minerArray = miner->Option.getOr([])
@@ -124,5 +144,19 @@ let generateBooleanHierarchy = (filterState: blockFilterState) => {
     }
 
     Array.join(lines, "\n")
+  }
+}
+
+let generateBooleanHierarchy = (filterState: blockFilterState) => {
+  switch excludeContent(filterState) {
+  | None => generateFieldsHierarchy(filterState)
+  | Some(ex) =>
+    let includeTree = isEmptyBlockFields(filterState)
+      ? None
+      : Some(generateFieldsHierarchy(filterState))
+    BooleanLogicFormat.composeHierarchyWithNot(
+      ~includeTree,
+      ~excludeTree=generateFieldsHierarchy(ex),
+    )
   }
 }

--- a/src/BlockFilter.res
+++ b/src/BlockFilter.res
@@ -164,9 +164,10 @@ let make = (
   }
 
   let onExcludeChange = (newExclude: blockFilterState) => {
+    // Selections carry a single exclude level, so never persist a nested one
     let exclude = BlockBooleanLogicGenerator.isEmptyBlockFields(newExclude)
       ? None
-      : Some(newExclude)
+      : Some({...newExclude, exclude: ?None})
     onFilterChange({...filterState, ?exclude})
   }
 

--- a/src/BlockFilter.res
+++ b/src/BlockFilter.res
@@ -2,6 +2,149 @@ open QueryStructure
 
 type blockFilterState = QueryStructure.blockSelection
 
+let emptyBlockFields: blockFilterState = {hash: None, miner: None}
+
+// Editor for a block filter's fields. Used for the filter itself and, bound to
+// `filterState.exclude`, for its exclusions.
+module FilterFields = {
+  @react.component
+  let make = (~filterState: blockFilterState, ~onFilterChange: blockFilterState => unit) => {
+    let (newHash, setNewHash) = React.useState(() => "")
+    let (newMiner, setNewMiner) = React.useState(() => "")
+
+    let addHash = () => {
+      if newHash !== "" && newHash->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          hash: Some(Array.concat(filterState.hash->Option.getOr([]), [newHash])),
+        })
+        setNewHash(_ => "")
+      }
+    }
+
+    let removeHash = index => {
+      let currentArray = filterState.hash->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        hash: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addMiner = () => {
+      if newMiner !== "" && newMiner->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          miner: Some(Array.concat(filterState.miner->Option.getOr([]), [newMiner])),
+        })
+        setNewMiner(_ => "")
+      }
+    }
+
+    let removeMiner = index => {
+      let currentArray = filterState.miner->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        miner: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    <>
+      // Block Hashes
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Block Hashes"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <input
+            type_="text"
+            value={newHash}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewHash(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <button
+            onClick={_ => addHash()}
+            disabled={String.length(newHash) == 0 || !(newHash->String.startsWith("0x"))}
+            className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {(
+              Array.length(filterState.hash->Option.getOr([])) > 0
+                ? "Add (via OR) Hash"
+                : "Add Hash"
+            )->React.string}
+          </button>
+        </div>
+        <div className="space-y-2">
+          {Array.mapWithIndex(filterState.hash->Option.getOr([]), (hash, index) =>
+            <div
+              key={Int.toString(index)}
+              className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
+            >
+              <span className="text-sm font-mono text-gray-800"> {hash->React.string} </span>
+              <button
+                onClick={_ => removeHash(index)} className="text-red-600 hover:text-red-800 text-sm"
+              >
+                {"Remove"->React.string}
+              </button>
+            </div>
+          )->React.array}
+        </div>
+      </div>
+
+      // Miner Addresses
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Miner Addresses"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <input
+            type_="text"
+            value={newMiner}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewMiner(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <button
+            onClick={_ => addMiner()}
+            disabled={String.length(newMiner) == 0 || !(newMiner->String.startsWith("0x"))}
+            className="px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {(
+              Array.length(filterState.miner->Option.getOr([])) > 0
+                ? "Add (via OR) Miner"
+                : "Add Miner"
+            )->React.string}
+          </button>
+        </div>
+        <div className="space-y-2">
+          {Array.mapWithIndex(filterState.miner->Option.getOr([]), (miner, index) =>
+            <div
+              key={Int.toString(index)}
+              className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
+            >
+              <span className="text-sm font-mono text-gray-800"> {miner->React.string} </span>
+              <button
+                onClick={_ => removeMiner(index)}
+                className="text-red-600 hover:text-red-800 text-sm"
+              >
+                {"Remove"->React.string}
+              </button>
+            </div>
+          )->React.array}
+        </div>
+      </div>
+    </>
+  }
+}
+
 @react.component
 let make = (
   ~filterState: blockFilterState,
@@ -11,9 +154,6 @@ let make = (
   ~isExpanded: bool,
   ~onToggleExpand,
 ) => {
-  let (newHash, setNewHash) = React.useState(() => "")
-  let (newMiner, setNewMiner) = React.useState(() => "")
-
   let titanBuilderExample: blockFilterState = {
     hash: None,
     miner: Some(["0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97"]),
@@ -23,62 +163,24 @@ let make = (
     onFilterChange(titanBuilderExample)
   }
 
-  let addHash = () => {
-    if newHash !== "" && newHash->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        hash: Some(Array.concat(filterState.hash->Option.getOr([]), [newHash])),
-      })
-      setNewHash(_ => "")
-    }
-  }
-
-  let removeHash = index => {
-    let currentArray = filterState.hash->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      hash: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addMiner = () => {
-    if newMiner !== "" && newMiner->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        miner: Some(Array.concat(filterState.miner->Option.getOr([]), [newMiner])),
-      })
-      setNewMiner(_ => "")
-    }
-  }
-
-  let removeMiner = index => {
-    let currentArray = filterState.miner->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      miner: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let _blockSelectionToStruct = (): option<blockSelection> => {
-    Some(filterState)
+  let onExcludeChange = (newExclude: blockFilterState) => {
+    let exclude = BlockBooleanLogicGenerator.isEmptyBlockFields(newExclude)
+      ? None
+      : Some(newExclude)
+    onFilterChange({...filterState, ?exclude})
   }
 
   let generateEnglishDescription = () => {
-    BlockBooleanLogicGenerator.generateEnglishDescription(
-      (filterState :> BlockBooleanLogicGenerator.blockFilterState),
-    )
+    BlockBooleanLogicGenerator.generateEnglishDescription(filterState)
   }
 
   let generateBooleanHierarchy = () => {
-    BlockBooleanLogicGenerator.generateBooleanHierarchy(
-      (filterState :> BlockBooleanLogicGenerator.blockFilterState),
-    )
+    BlockBooleanLogicGenerator.generateBooleanHierarchy(filterState)
   }
 
-  let generateCodeBlock = () => {
-    let {hash, miner} = filterState
+  // Pretty-printed JSON parts for a filter's own fields, indented by two spaces
+  let generateFieldParts = (state: blockFilterState) => {
+    let {hash, miner} = state
 
     let hashStr = switch hash {
     | Some(hashArray) if Array.length(hashArray) > 0 => {
@@ -96,7 +198,22 @@ let make = (
     | _ => ""
     }
 
-    let parts = [hashStr, minerStr]->Array.filter(str => str !== "")
+    [hashStr, minerStr]->Array.filter(str => str !== "")
+  }
+
+  let generateCodeBlock = () => {
+    let parts = generateFieldParts(filterState)
+    let parts = switch BlockBooleanLogicGenerator.excludeContent(filterState) {
+    | Some(ex) =>
+      let excludeParts = generateFieldParts(ex)->Array.map(part =>
+        part
+        ->String.split("\n")
+        ->Array.map(line => `  ${line}`)
+        ->Array.join("\n")
+      )
+      Array.concat(parts, [`  "exclude": {\n${Array.join(excludeParts, ",\n")}\n  }`])
+    | None => parts
+    }
     if Array.length(parts) > 0 {
       `{\n${Array.join(parts, ",\n")}\n}`
     } else {
@@ -104,9 +221,8 @@ let make = (
     }
   }
 
-  let hasFilters =
-    Array.length(filterState.hash->Option.getOr([])) > 0 ||
-      Array.length(filterState.miner->Option.getOr([])) > 0
+  let hasExclusions = BlockBooleanLogicGenerator.excludeContent(filterState)->Option.isSome
+  let hasFilters = !BlockBooleanLogicGenerator.isEmptyBlockFields(filterState) || hasExclusions
 
   <div
     className="relative bg-white rounded-xl border border-slate-200 shadow-sm transition-all w-full"
@@ -171,97 +287,14 @@ let make = (
             </button>
           </div>
 
-          // Block Hashes
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Block Hashes"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <input
-                type_="text"
-                value={newHash}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewHash(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <button
-                onClick={_ => addHash()}
-                disabled={String.length(newHash) == 0 || !(newHash->String.startsWith("0x"))}
-                className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {(
-                  Array.length(filterState.hash->Option.getOr([])) > 0
-                    ? "Add (via OR) Hash"
-                    : "Add Hash"
-                )->React.string}
-              </button>
-            </div>
-            <div className="space-y-2">
-              {Array.mapWithIndex(filterState.hash->Option.getOr([]), (hash, index) =>
-                <div
-                  key={Int.toString(index)}
-                  className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
-                >
-                  <span className="text-sm font-mono text-gray-800"> {hash->React.string} </span>
-                  <button
-                    onClick={_ => removeHash(index)}
-                    className="text-red-600 hover:text-red-800 text-sm"
-                  >
-                    {"Remove"->React.string}
-                  </button>
-                </div>
-              )->React.array}
-            </div>
-          </div>
+          <FilterFields filterState onFilterChange />
 
-          // Miner Addresses
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Miner Addresses"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <input
-                type_="text"
-                value={newMiner}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewMiner(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <button
-                onClick={_ => addMiner()}
-                disabled={String.length(newMiner) == 0 || !(newMiner->String.startsWith("0x"))}
-                className="px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {(
-                  Array.length(filterState.miner->Option.getOr([])) > 0
-                    ? "Add (via OR) Miner"
-                    : "Add Miner"
-                )->React.string}
-              </button>
-            </div>
-            <div className="space-y-2">
-              {Array.mapWithIndex(filterState.miner->Option.getOr([]), (miner, index) =>
-                <div
-                  key={Int.toString(index)}
-                  className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
-                >
-                  <span className="text-sm font-mono text-gray-800"> {miner->React.string} </span>
-                  <button
-                    onClick={_ => removeMiner(index)}
-                    className="text-red-600 hover:text-red-800 text-sm"
-                  >
-                    {"Remove"->React.string}
-                  </button>
-                </div>
-              )->React.array}
-            </div>
-          </div>
+          <ExcludeSection entityNamePlural="Blocks" hasExclusions>
+            <FilterFields
+              filterState={filterState.exclude->Option.getOr(emptyBlockFields)}
+              onFilterChange={onExcludeChange}
+            />
+          </ExcludeSection>
 
           // English Description and Boolean Logic
           <div className="mt-6">

--- a/src/BooleanLogicFormat.res
+++ b/src/BooleanLogicFormat.res
@@ -1,0 +1,38 @@
+// Shared helpers for folding a selection's `exclude` filter into the English
+// descriptions and ASCII boolean-logic trees produced by the *BooleanLogicGenerator
+// modules.
+
+let needsParens = (desc: string) => String.includes(desc, " AND ") || String.includes(desc, " OR ")
+
+// Compose "include AND NOT (exclude)". `include_` is "" when the filter has no
+// include conditions (i.e. it matches everything except the exclusions).
+let composeDescriptionWithNot = (~include_: string, ~exclude: string) =>
+  if include_ === "" {
+    `NOT (${exclude})`
+  } else {
+    let includePart = needsParens(include_) ? `(${include_})` : include_
+    `${includePart} AND NOT (${exclude})`
+  }
+
+// Prefix the first line of a rendered sub-tree and indent its remaining lines.
+let indentSubTree = (tree: string, ~firstPrefix: string, ~restPrefix: string) =>
+  String.split(tree, "\n")->Array.mapWithIndex((line, i) =>
+    i === 0 ? `${firstPrefix}${line}` : `${restPrefix}${line}`
+  )
+
+// Compose a hierarchy with a NOT branch for the exclude filter. `includeTree`
+// is None when the filter has no include conditions.
+let composeHierarchyWithNot = (~includeTree: option<string>, ~excludeTree: string) => {
+  let lines = switch includeTree {
+  | Some(include_) =>
+    ["AND"]
+    ->Array.concat(indentSubTree(include_, ~firstPrefix="├── ", ~restPrefix="│   "))
+    ->Array.concat(["└── NOT"])
+    ->Array.concat(
+      indentSubTree(excludeTree, ~firstPrefix="    └── ", ~restPrefix="        "),
+    )
+  | None =>
+    ["NOT"]->Array.concat(indentSubTree(excludeTree, ~firstPrefix="└── ", ~restPrefix="    "))
+  }
+  Array.join(lines, "\n")
+}

--- a/src/BooleanLogicGenerator.res
+++ b/src/BooleanLogicGenerator.res
@@ -2,65 +2,42 @@ open QueryStructure
 
 type filterState = QueryStructure.logSelection
 
-// Helper function to check if a filter is empty
-let isEmptyFilter = (filterState: filterState) => {
+// Helper function to check if a log filter's own fields are empty (ignoring exclude)
+let isEmptyLogFields = (filterState: filterState) => {
   let {address, topics} = filterState
   let addressArray = address->Option.getOr([])
   let topicsArray = topics->Option.getOr([])
   Array.length(addressArray) === 0 && Array.length(topicsArray) === 0
 }
 
-// Helper function to check if a transaction filter is empty
-let isEmptyTransactionFilter = (filterState: QueryStructure.transactionSelection) => {
-  let {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList} = filterState
-  let fromArray = from_->Option.getOr([])
-  let toArray = to_->Option.getOr([])
-  let sighashArray = sighash->Option.getOr([])
-  let typeArray = type_->Option.getOr([])
-  let contractAddressArray = contractAddress->Option.getOr([])
-  let hashArray = hash->Option.getOr([])
-  let authArray = authorizationList->Option.getOr([])
+// Returns a log filter's exclude filter only when it actually has conditions
+let logExcludeContent = (filterState: filterState): option<filterState> =>
+  switch filterState.exclude {
+  | Some(ex) if !isEmptyLogFields(ex) => Some(ex)
+  | _ => None
+  }
 
-  Array.length(fromArray) === 0 &&
-  Array.length(toArray) === 0 &&
-  Array.length(sighashArray) === 0 &&
-  Option.isNone(status) &&
-  Array.length(typeArray) === 0 &&
-  Array.length(contractAddressArray) === 0 &&
-  Array.length(hashArray) === 0 &&
-  Array.length(authArray) === 0
-}
+// Helper function to check if a filter is empty
+let isEmptyFilter = (filterState: filterState) =>
+  isEmptyLogFields(filterState) && logExcludeContent(filterState)->Option.isNone
+
+// Helper function to check if a transaction filter is empty
+let isEmptyTransactionFilter = (filterState: QueryStructure.transactionSelection) =>
+  TransactionBooleanLogicGenerator.isEmptyTransactionFields(filterState) &&
+  TransactionBooleanLogicGenerator.excludeContent(filterState)->Option.isNone
 
 // Helper function to check if a block filter is empty
-let isEmptyBlockFilter = (filterState: QueryStructure.blockSelection) => {
-  let {hash, miner} = filterState
-  let hashArray = hash->Option.getOr([])
-  let minerArray = miner->Option.getOr([])
-  Array.length(hashArray) === 0 && Array.length(minerArray) === 0
-}
+let isEmptyBlockFilter = (filterState: QueryStructure.blockSelection) =>
+  BlockBooleanLogicGenerator.isEmptyBlockFields(filterState) &&
+  BlockBooleanLogicGenerator.excludeContent(filterState)->Option.isNone
 
 // Helper function to check if a trace filter is empty
-let isEmptyTraceFilter = (filterState: QueryStructure.traceSelection) => {
-  let {from_, to_, address, callType, rewardType, type_, sighash} = filterState
-  let fromArray = from_->Option.getOr([])
-  let toArray = to_->Option.getOr([])
-  let addressArray = address->Option.getOr([])
-  let callTypeArray = callType->Option.getOr([])
-  let rewardTypeArray = rewardType->Option.getOr([])
-  let typeArray = type_->Option.getOr([])
-  let sighashArray = sighash->Option.getOr([])
+let isEmptyTraceFilter = (filterState: QueryStructure.traceSelection) =>
+  TraceBooleanLogicGenerator.isEmptyTraceFields(filterState) &&
+  TraceBooleanLogicGenerator.excludeContent(filterState)->Option.isNone
 
-  Array.length(fromArray) === 0 &&
-  Array.length(toArray) === 0 &&
-  Array.length(addressArray) === 0 &&
-  Array.length(callTypeArray) === 0 &&
-  Array.length(rewardTypeArray) === 0 &&
-  Array.length(typeArray) === 0 &&
-  Array.length(sighashArray) === 0
-}
-
-// Helper function to generate a clean filter description (without "Match logs where:" prefix)
-let generateFilterDescription = (filterState: filterState) => {
+// Description of a log filter's own fields (ignoring exclude), "" when empty
+let generateLogFieldsDescription = (filterState: filterState) => {
   let {address, topics} = filterState
   let addressArray = address->Option.getOr([])
   let topicsArray = topics->Option.getOr([])
@@ -98,6 +75,19 @@ let generateFilterDescription = (filterState: filterState) => {
   }
 
   Array.join(parts, " AND ")
+}
+
+// Helper function to generate a clean filter description (without "Match logs where:" prefix)
+let generateFilterDescription = (filterState: filterState) => {
+  let include_ = generateLogFieldsDescription(filterState)
+  switch logExcludeContent(filterState) {
+  | Some(ex) =>
+    BooleanLogicFormat.composeDescriptionWithNot(
+      ~include_,
+      ~exclude=generateLogFieldsDescription(ex),
+    )
+  | None => include_
+  }
 }
 
 // Helper function to generate transaction filter description
@@ -276,54 +266,16 @@ let generateMultiTraceFilterDescription = (
 }
 
 let generateEnglishDescription = (filterState: filterState) => {
-  let {address, topics} = filterState
-  let addressArray = address->Option.getOr([])
-  let topicsArray = topics->Option.getOr([])
-
-  if Array.length(addressArray) === 0 && Array.length(topicsArray) === 0 {
+  let description = generateFilterDescription(filterState)
+  if description === "" {
     "No filters applied - will match all logs"
   } else {
-    let parts = []
-
-    // Address condition
-    if Array.length(addressArray) > 0 {
-      let addressCondition = if Array.length(addressArray) === 1 {
-        `the contract address is ${Array.getUnsafe(addressArray, 0)}`
-      } else {
-        let addressList = Array.join(addressArray, " OR ")
-        `the contract address is ${addressList}`
-      }
-      parts->Array.push(addressCondition)->ignore
-    }
-
-    // Topic conditions
-    let topicConditions = []
-    Array.forEachWithIndex(topicsArray, (topicArray, i) => {
-      if Array.length(topicArray) > 0 {
-        let condition = if Array.length(topicArray) === 1 {
-          `topic[${Int.toString(i)}] is ${Array.getUnsafe(topicArray, 0)}`
-        } else {
-          let topicList = Array.join(topicArray, " OR ")
-          `topic[${Int.toString(i)}] is ${topicList}`
-        }
-        topicConditions->Array.push(condition)->ignore
-      }
-    })
-
-    if Array.length(topicConditions) > 0 {
-      let topicCondition = Array.join(topicConditions, " AND ")
-      parts->Array.push(topicCondition)->ignore
-    }
-
-    if Array.length(parts) > 0 {
-      `Match logs where: ${Array.join(parts, " AND ")}`
-    } else {
-      "No filters applied - will match all logs"
-    }
+    `Match logs where: ${description}`
   }
 }
 
-let generateBooleanHierarchy = (filterState: filterState) => {
+// Hierarchy of a log filter's own fields, ignoring any exclude filter
+let generateLogFieldsHierarchy = (filterState: filterState) => {
   let {address, topics} = filterState
 
   let addressArray = address->Option.getOr([])
@@ -438,6 +390,20 @@ let generateBooleanHierarchy = (filterState: filterState) => {
     }
 
     Array.join(lines, "\n")
+  }
+}
+
+let generateBooleanHierarchy = (filterState: filterState) => {
+  switch logExcludeContent(filterState) {
+  | None => generateLogFieldsHierarchy(filterState)
+  | Some(ex) =>
+    let includeTree = isEmptyLogFields(filterState)
+      ? None
+      : Some(generateLogFieldsHierarchy(filterState))
+    BooleanLogicFormat.composeHierarchyWithNot(
+      ~includeTree,
+      ~excludeTree=generateLogFieldsHierarchy(ex),
+    )
   }
 }
 

--- a/src/ExcludeSection.res
+++ b/src/ExcludeSection.res
@@ -1,0 +1,24 @@
+// Wrapper for the exclude-filter editor inside a filter card. The children are
+// the same field inputs as the include section, bound to the selection's
+// `exclude` filter.
+@react.component
+let make = (~entityNamePlural: string, ~hasExclusions: bool, ~children) => {
+  <div className="mb-6 border border-rose-200 rounded-xl overflow-hidden">
+    <div className="bg-rose-50 px-4 py-3 border-b border-rose-100">
+      <div className="flex items-center space-x-2">
+        <h4 className="text-sm font-semibold text-rose-700"> {"Exclude"->React.string} </h4>
+        {hasExclusions
+          ? <span
+              className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-rose-100 text-rose-700"
+            >
+              {"Active"->React.string}
+            </span>
+          : React.null}
+      </div>
+      <p className="text-xs text-rose-600 mt-1">
+        {`${entityNamePlural} matching the conditions below are excluded from this filter's results, even when they match the conditions above. Leave empty to exclude nothing.`->React.string}
+      </p>
+    </div>
+    <div className="p-4"> {children} </div>
+  </div>
+}

--- a/src/LogFilter.res
+++ b/src/LogFilter.res
@@ -2,6 +2,203 @@ open QueryStructure
 
 type filterState = QueryStructure.logSelection
 
+let emptyLogFields: filterState = {address: None, topics: None}
+
+// Editor for a log filter's fields. Used for the filter itself and, bound to
+// `filterState.exclude`, for its exclusions.
+module FilterFields = {
+  @react.component
+  let make = (~filterState: filterState, ~onFilterChange: filterState => unit) => {
+    let (newAddress, setNewAddress) = React.useState(() => "")
+    let (newTopic, setNewTopic) = React.useState(() => "")
+    let (currentTopicIndex, setCurrentTopicIndex) = React.useState(() => 0)
+
+    let addAddress = () => {
+      if newAddress !== "" && newAddress->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          address: Some(Array.concat(filterState.address->Option.getOr([]), [newAddress])),
+        })
+        setNewAddress(_ => "")
+      }
+    }
+
+    let removeAddress = index => {
+      let currentArray = filterState.address->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        address: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addTopic = () => {
+      if newTopic !== "" && newTopic->String.startsWith("0x") {
+        let currentIndex: int = currentTopicIndex
+        let requiredLength = max(
+          filterState.topics->Option.getOr([])->Array.length,
+          currentIndex + 1,
+        )
+        let paddedTopics = Belt.Array.makeBy(requiredLength, i => {
+          if i < filterState.topics->Option.getOr([])->Array.length {
+            Array.getUnsafe(filterState.topics->Option.getOr([]), i)
+          } else {
+            []
+          }
+        })
+
+        let existingTopics = Belt.Array.get(paddedTopics, currentIndex)->Option.getOr([])
+        let newTopics = Array.concat(existingTopics, [newTopic])
+        Array.setUnsafe(paddedTopics, currentIndex, newTopics)
+
+        onFilterChange({
+          ...filterState,
+          topics: Some(paddedTopics),
+        })
+        setNewTopic(_ => "")
+      }
+    }
+
+    let removeTopic = (topicIndex, itemIndex) => {
+      let currentTopics = filterState.topics->Option.getOr([])
+      let topicArray = Belt.Array.get(currentTopics, topicIndex)->Option.getOr([])
+      let newTopicArray = Belt.Array.keepWithIndex(topicArray, (_, i) => i !== itemIndex)
+      let newTopics = Array.mapWithIndex(currentTopics, (topic, i) =>
+        i === topicIndex ? newTopicArray : topic
+      )
+      onFilterChange({
+        ...filterState,
+        topics: Array.length(newTopics) > 0 && Array.some(newTopics, arr => Array.length(arr) > 0)
+          ? Some(newTopics)
+          : None,
+      })
+    }
+
+    <>
+      // Address Filters
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-slate-700 mb-2">
+          {"Contract Addresses"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <input
+            type_="text"
+            value={newAddress}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewAddress(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-colors"
+          />
+          <button
+            onClick={_ => addAddress()}
+            disabled={String.length(newAddress) == 0 || !(newAddress->String.startsWith("0x"))}
+            className="px-4 py-2 bg-slate-700 text-white text-sm font-medium rounded-lg hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {(
+              Array.length(filterState.address->Option.getOr([])) > 0
+                ? "Add (via OR) Address"
+                : "Add Address"
+            )->React.string}
+          </button>
+        </div>
+        <div className="space-y-2">
+          {Array.mapWithIndex(filterState.address->Option.getOr([]), (address, index) =>
+            <div
+              key={Int.toString(index)}
+              className="flex items-center justify-between bg-slate-50 px-3 py-2 rounded-lg border border-slate-100"
+            >
+              <span className="text-sm font-mono text-slate-800"> {address->React.string} </span>
+              <button
+                onClick={_ => removeAddress(index)}
+                className="text-red-600 hover:text-red-800 text-sm font-medium transition-colors"
+              >
+                {"Remove"->React.string}
+              </button>
+            </div>
+          )->React.array}
+        </div>
+      </div>
+
+      // Topic Filters
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-slate-700 mb-2">
+          {"Event Topics"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <select
+            value={Int.toString(currentTopicIndex)}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              switch Int.fromString(target["value"]) {
+              | Some(index) => setCurrentTopicIndex(_ => index)
+              | None => ()
+              }
+            }}
+            className="border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-500 transition-colors"
+          >
+            {Array.mapWithIndex(Belt.Array.range(0, 3), (_, i) =>
+              <option key={Int.toString(i)} value={Int.toString(i)}>
+                {`Topic ${Int.toString(i)}`->React.string}
+              </option>
+            )->React.array}
+          </select>
+          <input
+            type_="text"
+            value={newTopic}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewTopic(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-colors"
+          />
+          <button
+            onClick={_ => addTopic()}
+            disabled={String.length(newTopic) == 0 || !(newTopic->String.startsWith("0x"))}
+            className="px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-lg hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {(
+              currentTopicIndex < Array.length(filterState.topics->Option.getOr([])) &&
+                Array.length(
+                  Array.getUnsafe(filterState.topics->Option.getOr([]), currentTopicIndex),
+                ) > 0
+                ? "Add (via OR) Topic"
+                : "Add Topic"
+            )->React.string}
+          </button>
+        </div>
+        <div className="space-y-3">
+          {Array.mapWithIndex(filterState.topics->Option.getOr([]), (topicArray, topicIndex) =>
+            <div key={Int.toString(topicIndex)} className="border border-gray-200 rounded-md p-3">
+              <h4 className="text-sm font-medium text-gray-700 mb-2">
+                {`Topic ${Int.toString(topicIndex)}`->React.string}
+              </h4>
+              <div className="space-y-2">
+                {Array.mapWithIndex(topicArray, (topic, itemIndex) =>
+                  <div
+                    key={`${Int.toString(topicIndex)}-${Int.toString(itemIndex)}`}
+                    className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
+                  >
+                    <span className="text-sm font-mono text-gray-800"> {topic->React.string} </span>
+                    <button
+                      onClick={_ => removeTopic(topicIndex, itemIndex)}
+                      className="text-red-600 hover:text-red-800 text-sm"
+                    >
+                      {"Remove"->React.string}
+                    </button>
+                  </div>
+                )->React.array}
+              </div>
+            </div>
+          )->React.array}
+        </div>
+      </div>
+    </>
+  }
+}
+
 @react.component
 let make = (
   ~filterState: filterState,
@@ -11,10 +208,6 @@ let make = (
   ~isExpanded: bool,
   ~onToggleExpand,
 ) => {
-  let (newAddress, setNewAddress) = React.useState(() => "")
-  let (newTopic, setNewTopic) = React.useState(() => "")
-  let (currentTopicIndex, setCurrentTopicIndex) = React.useState(() => 0)
-
   // Example filter states
   let transferEventsExample: filterState = {
     address: None,
@@ -30,6 +223,16 @@ let make = (
     ]),
   }
 
+  // Transfer events, excluding mints (transfers from the zero address)
+  let transfersExcludingMintsExample: filterState = {
+    address: None,
+    topics: Some([["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]]),
+    exclude: {
+      address: None,
+      topics: Some([[], ["0x0000000000000000000000000000000000000000000000000000000000000000"]]),
+    },
+  }
+
   let setTransferEventsExample = () => {
     onFilterChange(transferEventsExample)
   }
@@ -38,80 +241,26 @@ let make = (
     onFilterChange(burnEventsExample)
   }
 
-  let addAddress = () => {
-    if newAddress !== "" && newAddress->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        address: Some(Array.concat(filterState.address->Option.getOr([]), [newAddress])),
-      })
-      setNewAddress(_ => "")
-    }
+  let setTransfersExcludingMintsExample = () => {
+    onFilterChange(transfersExcludingMintsExample)
   }
 
-  let removeAddress = index => {
-    let currentArray = filterState.address->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      address: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addTopic = () => {
-    if newTopic !== "" && newTopic->String.startsWith("0x") {
-      let currentIndex: int = currentTopicIndex
-      let requiredLength = max(filterState.topics->Option.getOr([])->Array.length, currentIndex + 1)
-      let paddedTopics = Belt.Array.makeBy(requiredLength, i => {
-        if i < filterState.topics->Option.getOr([])->Array.length {
-          Array.getUnsafe(filterState.topics->Option.getOr([]), i)
-        } else {
-          []
-        }
-      })
-
-      let existingTopics = Belt.Array.get(paddedTopics, currentIndex)->Option.getOr([])
-      let newTopics = Array.concat(existingTopics, [newTopic])
-      Array.setUnsafe(paddedTopics, currentIndex, newTopics)
-
-      onFilterChange({
-        ...filterState,
-        topics: Some(paddedTopics),
-      })
-      setNewTopic(_ => "")
-    }
-  }
-
-  let removeTopic = (topicIndex, itemIndex) => {
-    let currentTopics = filterState.topics->Option.getOr([])
-    let topicArray = Belt.Array.get(currentTopics, topicIndex)->Option.getOr([])
-    let newTopicArray = Belt.Array.keepWithIndex(topicArray, (_, i) => i !== itemIndex)
-    let newTopics = Array.mapWithIndex(currentTopics, (topic, i) =>
-      i === topicIndex ? newTopicArray : topic
-    )
-    onFilterChange({
-      ...filterState,
-      topics: Array.length(newTopics) > 0 && Array.some(newTopics, arr => Array.length(arr) > 0)
-        ? Some(newTopics)
-        : None,
-    })
+  let onExcludeChange = (newExclude: filterState) => {
+    let exclude = BooleanLogicGenerator.isEmptyLogFields(newExclude) ? None : Some(newExclude)
+    onFilterChange({...filterState, ?exclude})
   }
 
   let generateEnglishDescription = () => {
-    BooleanLogicGenerator.generateEnglishDescription({
-      address: filterState.address,
-      topics: filterState.topics,
-    })
+    BooleanLogicGenerator.generateEnglishDescription(filterState)
   }
 
   let generateBooleanHierarchy = () => {
-    BooleanLogicGenerator.generateBooleanHierarchy({
-      address: filterState.address,
-      topics: filterState.topics,
-    })
+    BooleanLogicGenerator.generateBooleanHierarchy(filterState)
   }
 
-  let generateCodeBlock = () => {
-    let {address, topics} = filterState
+  // Pretty-printed JSON parts for a filter's own fields, indented by two spaces
+  let generateFieldParts = (state: filterState) => {
+    let {address, topics} = state
     let addressArray = address->Option.getOr([])
     let topicsArray = topics->Option.getOr([])
 
@@ -139,7 +288,22 @@ let make = (
       ""
     }
 
-    let parts = [addressStr, topicsStr]->Array.filter(str => str !== "")
+    [addressStr, topicsStr]->Array.filter(str => str !== "")
+  }
+
+  let generateCodeBlock = () => {
+    let parts = generateFieldParts(filterState)
+    let parts = switch BooleanLogicGenerator.logExcludeContent(filterState) {
+    | Some(ex) =>
+      let excludeParts = generateFieldParts(ex)->Array.map(part =>
+        part
+        ->String.split("\n")
+        ->Array.map(line => `  ${line}`)
+        ->Array.join("\n")
+      )
+      Array.concat(parts, [`  "exclude": {\n${Array.join(excludeParts, ",\n")}\n  }`])
+    | None => parts
+    }
     if Array.length(parts) > 0 {
       `{\n${Array.join(parts, ",\n")}\n}`
     } else {
@@ -147,9 +311,8 @@ let make = (
     }
   }
 
-  let hasFilters =
-    Array.length(filterState.address->Option.getOr([])) > 0 ||
-      Array.length(filterState.topics->Option.getOr([])) > 0
+  let hasExclusions = BooleanLogicGenerator.logExcludeContent(filterState)->Option.isSome
+  let hasFilters = !BooleanLogicGenerator.isEmptyFilter(filterState)
 
   <div
     className="relative bg-white rounded-xl border border-slate-200 shadow-sm transition-all w-full"
@@ -218,134 +381,22 @@ let make = (
             >
               {"Burn Events"->React.string}
             </button>
+            <button
+              onClick={_ => setTransfersExcludingMintsExample()}
+              className="px-2.5 py-1 bg-purple-600 text-white text-xs font-medium rounded-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 transition-colors"
+            >
+              {"Transfers (Excl. Mints)"->React.string}
+            </button>
           </div>
 
-          // Address Filters
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-slate-700 mb-2">
-              {"Contract Addresses"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <input
-                type_="text"
-                value={newAddress}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewAddress(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-colors"
-              />
-              <button
-                onClick={_ => addAddress()}
-                disabled={String.length(newAddress) == 0 || !(newAddress->String.startsWith("0x"))}
-                className="px-4 py-2 bg-slate-700 text-white text-sm font-medium rounded-lg hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                {(
-                  Array.length(filterState.address->Option.getOr([])) > 0
-                    ? "Add (via OR) Address"
-                    : "Add Address"
-                )->React.string}
-              </button>
-            </div>
-            <div className="space-y-2">
-              {Array.mapWithIndex(filterState.address->Option.getOr([]), (address, index) =>
-                <div
-                  key={Int.toString(index)}
-                  className="flex items-center justify-between bg-slate-50 px-3 py-2 rounded-lg border border-slate-100"
-                >
-                  <span className="text-sm font-mono text-slate-800">
-                    {address->React.string}
-                  </span>
-                  <button
-                    onClick={_ => removeAddress(index)}
-                    className="text-red-600 hover:text-red-800 text-sm font-medium transition-colors"
-                  >
-                    {"Remove"->React.string}
-                  </button>
-                </div>
-              )->React.array}
-            </div>
-          </div>
+          <FilterFields filterState onFilterChange />
 
-          // Topic Filters
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-slate-700 mb-2">
-              {"Event Topics"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <select
-                value={Int.toString(currentTopicIndex)}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  switch Int.fromString(target["value"]) {
-                  | Some(index) => setCurrentTopicIndex(_ => index)
-                  | None => ()
-                  }
-                }}
-                className="border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-500 transition-colors"
-              >
-                {Array.mapWithIndex(Belt.Array.range(0, 3), (_, i) =>
-                  <option key={Int.toString(i)} value={Int.toString(i)}>
-                    {`Topic ${Int.toString(i)}`->React.string}
-                  </option>
-                )->React.array}
-              </select>
-              <input
-                type_="text"
-                value={newTopic}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewTopic(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-slate-500 transition-colors"
-              />
-              <button
-                onClick={_ => addTopic()}
-                disabled={String.length(newTopic) == 0 || !(newTopic->String.startsWith("0x"))}
-                className="px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-lg hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                {(
-                  currentTopicIndex < Array.length(filterState.topics->Option.getOr([])) &&
-                    Array.length(
-                      Array.getUnsafe(filterState.topics->Option.getOr([]), currentTopicIndex),
-                    ) > 0
-                    ? "Add (via OR) Topic"
-                    : "Add Topic"
-                )->React.string}
-              </button>
-            </div>
-            <div className="space-y-3">
-              {Array.mapWithIndex(filterState.topics->Option.getOr([]), (topicArray, topicIndex) =>
-                <div
-                  key={Int.toString(topicIndex)} className="border border-gray-200 rounded-md p-3"
-                >
-                  <h4 className="text-sm font-medium text-gray-700 mb-2">
-                    {`Topic ${Int.toString(topicIndex)}`->React.string}
-                  </h4>
-                  <div className="space-y-2">
-                    {Array.mapWithIndex(topicArray, (topic, itemIndex) =>
-                      <div
-                        key={`${Int.toString(topicIndex)}-${Int.toString(itemIndex)}`}
-                        className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
-                      >
-                        <span className="text-sm font-mono text-gray-800">
-                          {topic->React.string}
-                        </span>
-                        <button
-                          onClick={_ => removeTopic(topicIndex, itemIndex)}
-                          className="text-red-600 hover:text-red-800 text-sm"
-                        >
-                          {"Remove"->React.string}
-                        </button>
-                      </div>
-                    )->React.array}
-                  </div>
-                </div>
-              )->React.array}
-            </div>
-          </div>
+          <ExcludeSection entityNamePlural="Logs" hasExclusions>
+            <FilterFields
+              filterState={filterState.exclude->Option.getOr(emptyLogFields)}
+              onFilterChange={onExcludeChange}
+            />
+          </ExcludeSection>
 
           // English Description and Boolean Logic
           <div className="mt-6">

--- a/src/LogFilter.res
+++ b/src/LogFilter.res
@@ -246,7 +246,10 @@ let make = (
   }
 
   let onExcludeChange = (newExclude: filterState) => {
-    let exclude = BooleanLogicGenerator.isEmptyLogFields(newExclude) ? None : Some(newExclude)
+    // Selections carry a single exclude level, so never persist a nested one
+    let exclude = BooleanLogicGenerator.isEmptyLogFields(newExclude)
+      ? None
+      : Some({...newExclude, exclude: ?None})
     onFilterChange({...filterState, ?exclude})
   }
 

--- a/src/QueryResults.res
+++ b/src/QueryResults.res
@@ -108,7 +108,7 @@ let make = (
     }
   }
 
-  let serializeLogFilter = (logFilter: logSelection) => {
+  let serializeLogFilterFields = (logFilter: logSelection) => {
     let addressJson = switch logFilter.address {
     | Some(addresses) if Array.length(addresses) > 0 =>
       let addressesStr = Array.map(addresses, addr => `"${addr}"`)->Array.join(", ")
@@ -126,12 +126,24 @@ let make = (
     | _ => ""
     }
 
-    let parts = [addressJson, topicsJson]->Array.filter(part => part !== "")
+    [addressJson, topicsJson]->Array.filter(part => part !== "")
+  }
+
+  let serializeLogFilter = (logFilter: logSelection) => {
+    let parts = serializeLogFilterFields(logFilter)
+    let parts = switch logFilter.exclude {
+    | Some(ex) =>
+      let excludeParts = serializeLogFilterFields(ex)
+      Array.length(excludeParts) > 0
+        ? Array.concat(parts, [`"exclude": {${Array.join(excludeParts, ", ")}}`])
+        : parts
+    | None => parts
+    }
     let content = Array.join(parts, ", ")
     `{${content}}`
   }
 
-  let serializeTransactionFilter = (transactionFilter: transactionSelection) => {
+  let serializeTransactionFilterFields = (transactionFilter: transactionSelection) => {
     let fromJson = switch transactionFilter.from_ {
     | Some(froms) if Array.length(froms) > 0 =>
       let fromsStr = Array.map(froms, addr => `"${addr}"`)->Array.join(", ")
@@ -202,22 +214,33 @@ let make = (
     | _ => None
     }
 
-    let allParts =
-      [
-        fromJson,
-        toJson,
-        sighashJson,
-        statusJson,
-        typeJson,
-        contractAddressJson,
-        hashJson,
-        authorizationListJson,
-      ]->Array.filterMap(x => x)
-    let content = Array.join(allParts, ", ")
+    [
+      fromJson,
+      toJson,
+      sighashJson,
+      statusJson,
+      typeJson,
+      contractAddressJson,
+      hashJson,
+      authorizationListJson,
+    ]->Array.filterMap(x => x)
+  }
+
+  let serializeTransactionFilter = (transactionFilter: transactionSelection) => {
+    let parts = serializeTransactionFilterFields(transactionFilter)
+    let parts = switch transactionFilter.exclude {
+    | Some(ex) =>
+      let excludeParts = serializeTransactionFilterFields(ex)
+      Array.length(excludeParts) > 0
+        ? Array.concat(parts, [`"exclude": {${Array.join(excludeParts, ", ")}}`])
+        : parts
+    | None => parts
+    }
+    let content = Array.join(parts, ", ")
     `{${content}}`
   }
 
-  let serializeBlockFilter = (blockFilter: blockSelection) => {
+  let serializeBlockFilterFields = (blockFilter: blockSelection) => {
     let hashJson = switch blockFilter.hash {
     | Some(hashes) if Array.length(hashes) > 0 =>
       let hashesStr = Array.map(hashes, hash => `"${hash}"`)->Array.join(", ")
@@ -232,12 +255,24 @@ let make = (
     | _ => None
     }
 
-    let allParts = [hashJson, minerJson]->Array.filterMap(x => x)
-    let content = Array.join(allParts, ", ")
+    [hashJson, minerJson]->Array.filterMap(x => x)
+  }
+
+  let serializeBlockFilter = (blockFilter: blockSelection) => {
+    let parts = serializeBlockFilterFields(blockFilter)
+    let parts = switch blockFilter.exclude {
+    | Some(ex) =>
+      let excludeParts = serializeBlockFilterFields(ex)
+      Array.length(excludeParts) > 0
+        ? Array.concat(parts, [`"exclude": {${Array.join(excludeParts, ", ")}}`])
+        : parts
+    | None => parts
+    }
+    let content = Array.join(parts, ", ")
     `{${content}}`
   }
 
-  let serializeTraceFilter = (traceFilter: traceSelection) => {
+  let serializeTraceFilterFields = (traceFilter: traceSelection) => {
     let fromJson = switch traceFilter.from_ {
     | Some(froms) if Array.length(froms) > 0 =>
       let fromsStr = Array.map(froms, addr => `"${addr}"`)->Array.join(", ")
@@ -287,17 +322,28 @@ let make = (
     | _ => None
     }
 
-    let allParts =
-      [
-        fromJson,
-        toJson,
-        addressJson,
-        callTypeJson,
-        rewardTypeJson,
-        typeJson,
-        sighashJson,
-      ]->Array.filterMap(x => x)
-    let content = Array.join(allParts, ", ")
+    [
+      fromJson,
+      toJson,
+      addressJson,
+      callTypeJson,
+      rewardTypeJson,
+      typeJson,
+      sighashJson,
+    ]->Array.filterMap(x => x)
+  }
+
+  let serializeTraceFilter = (traceFilter: traceSelection) => {
+    let parts = serializeTraceFilterFields(traceFilter)
+    let parts = switch traceFilter.exclude {
+    | Some(ex) =>
+      let excludeParts = serializeTraceFilterFields(ex)
+      Array.length(excludeParts) > 0
+        ? Array.concat(parts, [`"exclude": {${Array.join(excludeParts, ", ")}}`])
+        : parts
+    | None => parts
+    }
+    let content = Array.join(parts, ", ")
     `{${content}}`
   }
 

--- a/src/TraceBooleanLogicGenerator.res
+++ b/src/TraceBooleanLogicGenerator.res
@@ -2,7 +2,27 @@ open QueryStructure
 
 type traceFilterState = QueryStructure.traceSelection
 
-let generateEnglishDescription = (filterState: traceFilterState) => {
+// True when the filter's own fields are empty, ignoring any exclude filter.
+let isEmptyTraceFields = (filterState: traceFilterState) => {
+  let {from_, to_, address, callType, rewardType, type_, sighash} = filterState
+  Array.length(from_->Option.getOr([])) === 0 &&
+  Array.length(to_->Option.getOr([])) === 0 &&
+  Array.length(address->Option.getOr([])) === 0 &&
+  Array.length(callType->Option.getOr([])) === 0 &&
+  Array.length(rewardType->Option.getOr([])) === 0 &&
+  Array.length(type_->Option.getOr([])) === 0 &&
+  Array.length(sighash->Option.getOr([])) === 0
+}
+
+// Returns the exclude filter only when it actually has conditions.
+let excludeContent = (filterState: traceFilterState): option<traceFilterState> =>
+  switch filterState.exclude {
+  | Some(ex) if !isEmptyTraceFields(ex) => Some(ex)
+  | _ => None
+  }
+
+// Description of the filter's own fields, "" when empty.
+let generateFieldsDescription = (filterState: traceFilterState) => {
   let {from_, to_, address, callType, rewardType, type_, sighash} = filterState
   let fromArray = from_->Option.getOr([])
   let toArray = to_->Option.getOr([])
@@ -12,102 +32,105 @@ let generateEnglishDescription = (filterState: traceFilterState) => {
   let typeArray = type_->Option.getOr([])
   let sighashArray = sighash->Option.getOr([])
 
-  let hasAnyFilter =
-    Array.length(fromArray) > 0 ||
-    Array.length(toArray) > 0 ||
-    Array.length(addressArray) > 0 ||
-    Array.length(callTypeArray) > 0 ||
-    Array.length(rewardTypeArray) > 0 ||
-    Array.length(typeArray) > 0 ||
-    Array.length(sighashArray) > 0
+  let parts = []
 
-  if !hasAnyFilter {
-    "No filters applied - will match all traces"
-  } else {
-    let parts = []
-
-    // From condition
-    if Array.length(fromArray) > 0 {
-      let fromCondition = if Array.length(fromArray) === 1 {
-        `the sender address is ${Array.getUnsafe(fromArray, 0)}`
-      } else {
-        let fromList = Array.join(fromArray, " OR ")
-        `the sender address is ${fromList}`
-      }
-      parts->Array.push(fromCondition)->ignore
+  // From condition
+  if Array.length(fromArray) > 0 {
+    let fromCondition = if Array.length(fromArray) === 1 {
+      `the sender address is ${Array.getUnsafe(fromArray, 0)}`
+    } else {
+      let fromList = Array.join(fromArray, " OR ")
+      `the sender address is ${fromList}`
     }
+    parts->Array.push(fromCondition)->ignore
+  }
 
-    // To condition
-    if Array.length(toArray) > 0 {
-      let toCondition = if Array.length(toArray) === 1 {
-        `the recipient address is ${Array.getUnsafe(toArray, 0)}`
-      } else {
-        let toList = Array.join(toArray, " OR ")
-        `the recipient address is ${toList}`
-      }
-      parts->Array.push(toCondition)->ignore
+  // To condition
+  if Array.length(toArray) > 0 {
+    let toCondition = if Array.length(toArray) === 1 {
+      `the recipient address is ${Array.getUnsafe(toArray, 0)}`
+    } else {
+      let toList = Array.join(toArray, " OR ")
+      `the recipient address is ${toList}`
     }
+    parts->Array.push(toCondition)->ignore
+  }
 
-    // Address condition
-    if Array.length(addressArray) > 0 {
-      let addressCondition = if Array.length(addressArray) === 1 {
-        `the address is ${Array.getUnsafe(addressArray, 0)}`
-      } else {
-        let addressList = Array.join(addressArray, " OR ")
-        `the address is ${addressList}`
-      }
-      parts->Array.push(addressCondition)->ignore
+  // Address condition
+  if Array.length(addressArray) > 0 {
+    let addressCondition = if Array.length(addressArray) === 1 {
+      `the address is ${Array.getUnsafe(addressArray, 0)}`
+    } else {
+      let addressList = Array.join(addressArray, " OR ")
+      `the address is ${addressList}`
     }
+    parts->Array.push(addressCondition)->ignore
+  }
 
-    // Call type condition
-    if Array.length(callTypeArray) > 0 {
-      let callTypeCondition = if Array.length(callTypeArray) === 1 {
-        `the call type is ${Array.getUnsafe(callTypeArray, 0)}`
-      } else {
-        let callTypeList = Array.join(callTypeArray, " OR ")
-        `the call type is ${callTypeList}`
-      }
-      parts->Array.push(callTypeCondition)->ignore
+  // Call type condition
+  if Array.length(callTypeArray) > 0 {
+    let callTypeCondition = if Array.length(callTypeArray) === 1 {
+      `the call type is ${Array.getUnsafe(callTypeArray, 0)}`
+    } else {
+      let callTypeList = Array.join(callTypeArray, " OR ")
+      `the call type is ${callTypeList}`
     }
+    parts->Array.push(callTypeCondition)->ignore
+  }
 
-    // Reward type condition
-    if Array.length(rewardTypeArray) > 0 {
-      let rewardTypeCondition = if Array.length(rewardTypeArray) === 1 {
-        `the reward type is ${Array.getUnsafe(rewardTypeArray, 0)}`
-      } else {
-        let rewardTypeList = Array.join(rewardTypeArray, " OR ")
-        `the reward type is ${rewardTypeList}`
-      }
-      parts->Array.push(rewardTypeCondition)->ignore
+  // Reward type condition
+  if Array.length(rewardTypeArray) > 0 {
+    let rewardTypeCondition = if Array.length(rewardTypeArray) === 1 {
+      `the reward type is ${Array.getUnsafe(rewardTypeArray, 0)}`
+    } else {
+      let rewardTypeList = Array.join(rewardTypeArray, " OR ")
+      `the reward type is ${rewardTypeList}`
     }
+    parts->Array.push(rewardTypeCondition)->ignore
+  }
 
-    // Type condition
-    if Array.length(typeArray) > 0 {
-      let typeCondition = if Array.length(typeArray) === 1 {
-        `the type is ${Array.getUnsafe(typeArray, 0)}`
-      } else {
-        let typeList = Array.join(typeArray, " OR ")
-        `the type is ${typeList}`
-      }
-      parts->Array.push(typeCondition)->ignore
+  // Type condition
+  if Array.length(typeArray) > 0 {
+    let typeCondition = if Array.length(typeArray) === 1 {
+      `the type is ${Array.getUnsafe(typeArray, 0)}`
+    } else {
+      let typeList = Array.join(typeArray, " OR ")
+      `the type is ${typeList}`
     }
+    parts->Array.push(typeCondition)->ignore
+  }
 
-    // Sighash condition
-    if Array.length(sighashArray) > 0 {
-      let sighashCondition = if Array.length(sighashArray) === 1 {
-        `the function signature is ${Array.getUnsafe(sighashArray, 0)}`
-      } else {
-        let sighashList = Array.join(sighashArray, " OR ")
-        `the function signature is ${sighashList}`
-      }
-      parts->Array.push(sighashCondition)->ignore
+  // Sighash condition
+  if Array.length(sighashArray) > 0 {
+    let sighashCondition = if Array.length(sighashArray) === 1 {
+      `the function signature is ${Array.getUnsafe(sighashArray, 0)}`
+    } else {
+      let sighashList = Array.join(sighashArray, " OR ")
+      `the function signature is ${sighashList}`
     }
+    parts->Array.push(sighashCondition)->ignore
+  }
 
-    "Match traces where: " ++ Array.join(parts, " AND ")
+  Array.join(parts, " AND ")
+}
+
+let generateEnglishDescription = (filterState: traceFilterState) => {
+  let include_ = generateFieldsDescription(filterState)
+  switch excludeContent(filterState) {
+  | Some(ex) =>
+    let exclude = generateFieldsDescription(ex)
+    `Match traces where: ${BooleanLogicFormat.composeDescriptionWithNot(~include_, ~exclude)}`
+  | None =>
+    if include_ === "" {
+      "No filters applied - will match all traces"
+    } else {
+      `Match traces where: ${include_}`
+    }
   }
 }
 
-let generateBooleanHierarchy = (filterState: traceFilterState) => {
+// Hierarchy of the filter's own fields, ignoring any exclude filter.
+let generateFieldsHierarchy = (filterState: traceFilterState) => {
   let {from_, to_, address, callType, rewardType, type_, sighash} = filterState
   let fromArray = from_->Option.getOr([])
   let toArray = to_->Option.getOr([])
@@ -373,5 +396,19 @@ let generateBooleanHierarchy = (filterState: traceFilterState) => {
     }
 
     Array.join(lines, "\n")
+  }
+}
+
+let generateBooleanHierarchy = (filterState: traceFilterState) => {
+  switch excludeContent(filterState) {
+  | None => generateFieldsHierarchy(filterState)
+  | Some(ex) =>
+    let includeTree = isEmptyTraceFields(filterState)
+      ? None
+      : Some(generateFieldsHierarchy(filterState))
+    BooleanLogicFormat.composeHierarchyWithNot(
+      ~includeTree,
+      ~excludeTree=generateFieldsHierarchy(ex),
+    )
   }
 }

--- a/src/TraceFilter.res
+++ b/src/TraceFilter.res
@@ -2,6 +2,471 @@ open QueryStructure
 
 type traceFilterState = QueryStructure.traceSelection
 
+let emptyTraceFields: traceFilterState = {
+  from_: None,
+  to_: None,
+  address: None,
+  callType: None,
+  rewardType: None,
+  type_: None,
+  sighash: None,
+}
+
+// Editor for a trace filter's fields. Used for the filter itself and, bound to
+// `filterState.exclude`, for its exclusions.
+module FilterFields = {
+  @react.component
+  let make = (~filterState: traceFilterState, ~onFilterChange: traceFilterState => unit) => {
+    let (newFrom, setNewFrom) = React.useState(() => "")
+    let (newTo, setNewTo) = React.useState(() => "")
+    let (newAddress, setNewAddress) = React.useState(() => "")
+    let (newCallType, setNewCallType) = React.useState(() => "")
+    let (newRewardType, setNewRewardType) = React.useState(() => "")
+    let (newType, setNewType) = React.useState(() => "")
+    let (newSighash, setNewSighash) = React.useState(() => "")
+
+    let addFrom = () => {
+      if newFrom !== "" && newFrom->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          from_: Some(Array.concat(filterState.from_->Option.getOr([]), [newFrom])),
+        })
+        setNewFrom(_ => "")
+      }
+    }
+
+    let removeFrom = index => {
+      let currentArray = filterState.from_->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        from_: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addTo = () => {
+      if newTo !== "" && newTo->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          to_: Some(Array.concat(filterState.to_->Option.getOr([]), [newTo])),
+        })
+        setNewTo(_ => "")
+      }
+    }
+
+    let removeTo = index => {
+      let currentArray = filterState.to_->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        to_: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addAddress = () => {
+      if newAddress !== "" && newAddress->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          address: Some(Array.concat(filterState.address->Option.getOr([]), [newAddress])),
+        })
+        setNewAddress(_ => "")
+      }
+    }
+
+    let removeAddress = index => {
+      let currentArray = filterState.address->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        address: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addCallType = () => {
+      if newCallType !== "" {
+        onFilterChange({
+          ...filterState,
+          callType: Some(Array.concat(filterState.callType->Option.getOr([]), [newCallType])),
+        })
+        setNewCallType(_ => "")
+      }
+    }
+
+    let removeCallType = index => {
+      let currentArray = filterState.callType->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        callType: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addRewardType = () => {
+      if newRewardType !== "" {
+        onFilterChange({
+          ...filterState,
+          rewardType: Some(Array.concat(filterState.rewardType->Option.getOr([]), [newRewardType])),
+        })
+        setNewRewardType(_ => "")
+      }
+    }
+
+    let removeRewardType = index => {
+      let currentArray = filterState.rewardType->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        rewardType: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addType = () => {
+      if newType !== "" {
+        onFilterChange({
+          ...filterState,
+          type_: Some(Array.concat(filterState.type_->Option.getOr([]), [newType])),
+        })
+        setNewType(_ => "")
+      }
+    }
+
+    let removeType = index => {
+      let currentArray = filterState.type_->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        type_: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addSighash = () => {
+      if newSighash !== "" && newSighash->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          sighash: Some(Array.concat(filterState.sighash->Option.getOr([]), [newSighash])),
+        })
+        setNewSighash(_ => "")
+      }
+    }
+
+    let removeSighash = index => {
+      let currentArray = filterState.sighash->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        sighash: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    <>
+      // From addresses
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"From Addresses"->React.string}
+        </label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type_="text"
+            value={newFrom}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewFrom(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          />
+          <button
+            onClick={_ => addFrom()}
+            className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            {"Add"->React.string}
+          </button>
+        </div>
+        {Array.mapWithIndex(filterState.from_->Option.getOr([]), (address, index) =>
+          <div
+            key={address}
+            className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
+          >
+            <span className="text-sm text-gray-700 font-mono"> {address->React.string} </span>
+            <button onClick={_ => removeFrom(index)} className="text-red-400 hover:text-red-600">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        )->React.array}
+      </div>
+
+      // To addresses
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"To Addresses"->React.string}
+        </label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type_="text"
+            value={newTo}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewTo(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          />
+          <button
+            onClick={_ => addTo()}
+            className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            {"Add"->React.string}
+          </button>
+        </div>
+        {Array.mapWithIndex(filterState.to_->Option.getOr([]), (address, index) =>
+          <div
+            key={address}
+            className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
+          >
+            <span className="text-sm text-gray-700 font-mono"> {address->React.string} </span>
+            <button onClick={_ => removeTo(index)} className="text-red-400 hover:text-red-600">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        )->React.array}
+      </div>
+
+      // Addresses
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Addresses"->React.string}
+        </label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type_="text"
+            value={newAddress}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewAddress(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          />
+          <button
+            onClick={_ => addAddress()}
+            className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            {"Add"->React.string}
+          </button>
+        </div>
+        {Array.mapWithIndex(filterState.address->Option.getOr([]), (address, index) =>
+          <div
+            key={address}
+            className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
+          >
+            <span className="text-sm text-gray-700 font-mono"> {address->React.string} </span>
+            <button onClick={_ => removeAddress(index)} className="text-red-400 hover:text-red-600">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        )->React.array}
+      </div>
+
+      // Call types
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Call Types"->React.string}
+        </label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type_="text"
+            value={newCallType}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewCallType(_ => target["value"])
+            }}
+            placeholder="call, create, suicide..."
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          />
+          <button
+            onClick={_ => addCallType()}
+            className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            {"Add"->React.string}
+          </button>
+        </div>
+        {Array.mapWithIndex(filterState.callType->Option.getOr([]), (callType, index) =>
+          <div
+            key={callType}
+            className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
+          >
+            <span className="text-sm text-gray-700"> {callType->React.string} </span>
+            <button
+              onClick={_ => removeCallType(index)} className="text-red-400 hover:text-red-600"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        )->React.array}
+      </div>
+
+      // Reward types
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Reward Types"->React.string}
+        </label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type_="text"
+            value={newRewardType}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewRewardType(_ => target["value"])
+            }}
+            placeholder="block, uncle..."
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          />
+          <button
+            onClick={_ => addRewardType()}
+            className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            {"Add"->React.string}
+          </button>
+        </div>
+        {Array.mapWithIndex(filterState.rewardType->Option.getOr([]), (rewardType, index) =>
+          <div
+            key={rewardType}
+            className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
+          >
+            <span className="text-sm text-gray-700"> {rewardType->React.string} </span>
+            <button
+              onClick={_ => removeRewardType(index)} className="text-red-400 hover:text-red-600"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        )->React.array}
+      </div>
+
+      // Types
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Types"->React.string}
+        </label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type_="text"
+            value={newType}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewType(_ => target["value"])
+            }}
+            placeholder="call, create, suicide, reward..."
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          />
+          <button
+            onClick={_ => addType()}
+            className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            {"Add"->React.string}
+          </button>
+        </div>
+        {Array.mapWithIndex(filterState.type_->Option.getOr([]), (t, index) =>
+          <div
+            key={t}
+            className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
+          >
+            <span className="text-sm text-gray-700"> {t->React.string} </span>
+            <button onClick={_ => removeType(index)} className="text-red-400 hover:text-red-600">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        )->React.array}
+      </div>
+
+      // Sighash
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Function Signatures"->React.string}
+        </label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type_="text"
+            value={newSighash}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewSighash(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          />
+          <button
+            onClick={_ => addSighash()}
+            className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            {"Add"->React.string}
+          </button>
+        </div>
+        {Array.mapWithIndex(filterState.sighash->Option.getOr([]), (sighash, index) =>
+          <div
+            key={sighash}
+            className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
+          >
+            <span className="text-sm text-gray-700 font-mono"> {sighash->React.string} </span>
+            <button onClick={_ => removeSighash(index)} className="text-red-400 hover:text-red-600">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        )->React.array}
+      </div>
+    </>
+  }
+}
+
 @react.component
 let make = (
   ~filterState: traceFilterState,
@@ -11,53 +476,25 @@ let make = (
   ~isExpanded: bool,
   ~onToggleExpand,
 ) => {
-  let (newFrom, setNewFrom) = React.useState(() => "")
-  let (newTo, setNewTo) = React.useState(() => "")
-  let (newAddress, setNewAddress) = React.useState(() => "")
-  let (newCallType, setNewCallType) = React.useState(() => "")
-  let (newRewardType, setNewRewardType) = React.useState(() => "")
-  let (newType, setNewType) = React.useState(() => "")
-  let (newSighash, setNewSighash) = React.useState(() => "")
-
   // Example filter states
   let callExample: traceFilterState = {
-    from_: None,
-    to_: None,
-    address: None,
+    ...emptyTraceFields,
     callType: Some(["call"]),
-    rewardType: None,
-    type_: None,
-    sighash: None,
   }
 
   let createExample: traceFilterState = {
-    from_: None,
-    to_: None,
-    address: None,
+    ...emptyTraceFields,
     callType: Some(["create"]),
-    rewardType: None,
-    type_: None,
-    sighash: None,
   }
 
   let suicideExample: traceFilterState = {
-    from_: None,
-    to_: None,
-    address: None,
+    ...emptyTraceFields,
     callType: Some(["suicide"]),
-    rewardType: None,
-    type_: None,
-    sighash: None,
   }
 
   let rewardExample: traceFilterState = {
-    from_: None,
-    to_: None,
-    address: None,
-    callType: None,
+    ...emptyTraceFields,
     rewardType: Some(["block"]),
-    type_: None,
-    sighash: None,
   }
 
   let setCallExample = () => {
@@ -76,138 +513,14 @@ let make = (
     onFilterChange(rewardExample)
   }
 
-  let addFrom = () => {
-    if newFrom !== "" && newFrom->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        from_: Some(Array.concat(filterState.from_->Option.getOr([]), [newFrom])),
-      })
-      setNewFrom(_ => "")
-    }
+  let onExcludeChange = (newExclude: traceFilterState) => {
+    let exclude = TraceBooleanLogicGenerator.isEmptyTraceFields(newExclude)
+      ? None
+      : Some(newExclude)
+    onFilterChange({...filterState, ?exclude})
   }
 
-  let removeFrom = index => {
-    let currentArray = filterState.from_->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      from_: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addTo = () => {
-    if newTo !== "" && newTo->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        to_: Some(Array.concat(filterState.to_->Option.getOr([]), [newTo])),
-      })
-      setNewTo(_ => "")
-    }
-  }
-
-  let removeTo = index => {
-    let currentArray = filterState.to_->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      to_: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addAddress = () => {
-    if newAddress !== "" && newAddress->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        address: Some(Array.concat(filterState.address->Option.getOr([]), [newAddress])),
-      })
-      setNewAddress(_ => "")
-    }
-  }
-
-  let removeAddress = index => {
-    let currentArray = filterState.address->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      address: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addCallType = () => {
-    if newCallType !== "" {
-      onFilterChange({
-        ...filterState,
-        callType: Some(Array.concat(filterState.callType->Option.getOr([]), [newCallType])),
-      })
-      setNewCallType(_ => "")
-    }
-  }
-
-  let removeCallType = index => {
-    let currentArray = filterState.callType->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      callType: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addRewardType = () => {
-    if newRewardType !== "" {
-      onFilterChange({
-        ...filterState,
-        rewardType: Some(Array.concat(filterState.rewardType->Option.getOr([]), [newRewardType])),
-      })
-      setNewRewardType(_ => "")
-    }
-  }
-
-  let removeRewardType = index => {
-    let currentArray = filterState.rewardType->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      rewardType: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addType = () => {
-    if newType !== "" {
-      onFilterChange({
-        ...filterState,
-        type_: Some(Array.concat(filterState.type_->Option.getOr([]), [newType])),
-      })
-      setNewType(_ => "")
-    }
-  }
-
-  let removeType = index => {
-    let currentArray = filterState.type_->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      type_: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addSighash = () => {
-    if newSighash !== "" && newSighash->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        sighash: Some(Array.concat(filterState.sighash->Option.getOr([]), [newSighash])),
-      })
-      setNewSighash(_ => "")
-    }
-  }
-
-  let removeSighash = index => {
-    let currentArray = filterState.sighash->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      sighash: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
+  let hasExclusions = TraceBooleanLogicGenerator.excludeContent(filterState)->Option.isSome
 
   let generateEnglishDescription = () => {
     TraceBooleanLogicGenerator.generateEnglishDescription(filterState)
@@ -302,318 +615,16 @@ let make = (
             </div>
           </div>
 
-          // From addresses
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"From Addresses"->React.string}
-            </label>
-            <div className="flex gap-2 mb-2">
-              <input
-                type_="text"
-                value={newFrom}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewFrom(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-              />
-              <button
-                onClick={_ => addFrom()}
-                className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
-              >
-                {"Add"->React.string}
-              </button>
-            </div>
-            {Array.mapWithIndex(filterState.from_->Option.getOr([]), (address, index) =>
-              <div
-                key={address}
-                className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
-              >
-                <span className="text-sm text-gray-700 font-mono"> {address->React.string} </span>
-                <button
-                  onClick={_ => removeFrom(index)} className="text-red-400 hover:text-red-600"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-            )->React.array}
-          </div>
+          <FilterFields filterState onFilterChange />
 
-          // To addresses
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"To Addresses"->React.string}
-            </label>
-            <div className="flex gap-2 mb-2">
-              <input
-                type_="text"
-                value={newTo}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewTo(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          <ExcludeSection entityNamePlural="Traces" hasExclusions>
+            <div className="space-y-6">
+              <FilterFields
+                filterState={filterState.exclude->Option.getOr(emptyTraceFields)}
+                onFilterChange={onExcludeChange}
               />
-              <button
-                onClick={_ => addTo()}
-                className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
-              >
-                {"Add"->React.string}
-              </button>
             </div>
-            {Array.mapWithIndex(filterState.to_->Option.getOr([]), (address, index) =>
-              <div
-                key={address}
-                className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
-              >
-                <span className="text-sm text-gray-700 font-mono"> {address->React.string} </span>
-                <button onClick={_ => removeTo(index)} className="text-red-400 hover:text-red-600">
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-            )->React.array}
-          </div>
-
-          // Addresses
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Addresses"->React.string}
-            </label>
-            <div className="flex gap-2 mb-2">
-              <input
-                type_="text"
-                value={newAddress}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewAddress(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-              />
-              <button
-                onClick={_ => addAddress()}
-                className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
-              >
-                {"Add"->React.string}
-              </button>
-            </div>
-            {Array.mapWithIndex(filterState.address->Option.getOr([]), (address, index) =>
-              <div
-                key={address}
-                className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
-              >
-                <span className="text-sm text-gray-700 font-mono"> {address->React.string} </span>
-                <button
-                  onClick={_ => removeAddress(index)} className="text-red-400 hover:text-red-600"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-            )->React.array}
-          </div>
-
-          // Call types
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Call Types"->React.string}
-            </label>
-            <div className="flex gap-2 mb-2">
-              <input
-                type_="text"
-                value={newCallType}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewCallType(_ => target["value"])
-                }}
-                placeholder="call, create, suicide..."
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-              />
-              <button
-                onClick={_ => addCallType()}
-                className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
-              >
-                {"Add"->React.string}
-              </button>
-            </div>
-            {Array.mapWithIndex(filterState.callType->Option.getOr([]), (callType, index) =>
-              <div
-                key={callType}
-                className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
-              >
-                <span className="text-sm text-gray-700"> {callType->React.string} </span>
-                <button
-                  onClick={_ => removeCallType(index)} className="text-red-400 hover:text-red-600"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-            )->React.array}
-          </div>
-
-          // Reward types
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Reward Types"->React.string}
-            </label>
-            <div className="flex gap-2 mb-2">
-              <input
-                type_="text"
-                value={newRewardType}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewRewardType(_ => target["value"])
-                }}
-                placeholder="block, uncle..."
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-              />
-              <button
-                onClick={_ => addRewardType()}
-                className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
-              >
-                {"Add"->React.string}
-              </button>
-            </div>
-            {Array.mapWithIndex(filterState.rewardType->Option.getOr([]), (rewardType, index) =>
-              <div
-                key={rewardType}
-                className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
-              >
-                <span className="text-sm text-gray-700"> {rewardType->React.string} </span>
-                <button
-                  onClick={_ => removeRewardType(index)} className="text-red-400 hover:text-red-600"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-            )->React.array}
-          </div>
-
-          // Types
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Types"->React.string}
-            </label>
-            <div className="flex gap-2 mb-2">
-              <input
-                type_="text"
-                value={newType}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewType(_ => target["value"])
-                }}
-                placeholder="call, create, suicide, reward..."
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-              />
-              <button
-                onClick={_ => addType()}
-                className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
-              >
-                {"Add"->React.string}
-              </button>
-            </div>
-            {Array.mapWithIndex(filterState.type_->Option.getOr([]), (t, index) =>
-              <div
-                key={t}
-                className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
-              >
-                <span className="text-sm text-gray-700"> {t->React.string} </span>
-                <button
-                  onClick={_ => removeType(index)} className="text-red-400 hover:text-red-600"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-            )->React.array}
-          </div>
-
-          // Sighash
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Function Signatures"->React.string}
-            </label>
-            <div className="flex gap-2 mb-2">
-              <input
-                type_="text"
-                value={newSighash}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewSighash(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-              />
-              <button
-                onClick={_ => addSighash()}
-                className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
-              >
-                {"Add"->React.string}
-              </button>
-            </div>
-            {Array.mapWithIndex(filterState.sighash->Option.getOr([]), (sighash, index) =>
-              <div
-                key={sighash}
-                className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
-              >
-                <span className="text-sm text-gray-700 font-mono"> {sighash->React.string} </span>
-                <button
-                  onClick={_ => removeSighash(index)} className="text-red-400 hover:text-red-600"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-            )->React.array}
-          </div>
+          </ExcludeSection>
         </div>
       : React.null}
   </div>

--- a/src/TraceFilter.res
+++ b/src/TraceFilter.res
@@ -184,7 +184,7 @@ module FilterFields = {
         </div>
         {Array.mapWithIndex(filterState.from_->Option.getOr([]), (address, index) =>
           <div
-            key={address}
+            key={Int.toString(index)}
             className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
           >
             <span className="text-sm text-gray-700 font-mono"> {address->React.string} </span>
@@ -227,7 +227,7 @@ module FilterFields = {
         </div>
         {Array.mapWithIndex(filterState.to_->Option.getOr([]), (address, index) =>
           <div
-            key={address}
+            key={Int.toString(index)}
             className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
           >
             <span className="text-sm text-gray-700 font-mono"> {address->React.string} </span>
@@ -270,7 +270,7 @@ module FilterFields = {
         </div>
         {Array.mapWithIndex(filterState.address->Option.getOr([]), (address, index) =>
           <div
-            key={address}
+            key={Int.toString(index)}
             className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
           >
             <span className="text-sm text-gray-700 font-mono"> {address->React.string} </span>
@@ -313,7 +313,7 @@ module FilterFields = {
         </div>
         {Array.mapWithIndex(filterState.callType->Option.getOr([]), (callType, index) =>
           <div
-            key={callType}
+            key={Int.toString(index)}
             className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
           >
             <span className="text-sm text-gray-700"> {callType->React.string} </span>
@@ -358,7 +358,7 @@ module FilterFields = {
         </div>
         {Array.mapWithIndex(filterState.rewardType->Option.getOr([]), (rewardType, index) =>
           <div
-            key={rewardType}
+            key={Int.toString(index)}
             className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
           >
             <span className="text-sm text-gray-700"> {rewardType->React.string} </span>
@@ -403,7 +403,7 @@ module FilterFields = {
         </div>
         {Array.mapWithIndex(filterState.type_->Option.getOr([]), (t, index) =>
           <div
-            key={t}
+            key={Int.toString(index)}
             className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
           >
             <span className="text-sm text-gray-700"> {t->React.string} </span>
@@ -446,7 +446,7 @@ module FilterFields = {
         </div>
         {Array.mapWithIndex(filterState.sighash->Option.getOr([]), (sighash, index) =>
           <div
-            key={sighash}
+            key={Int.toString(index)}
             className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 mb-1"
           >
             <span className="text-sm text-gray-700 font-mono"> {sighash->React.string} </span>
@@ -514,9 +514,10 @@ let make = (
   }
 
   let onExcludeChange = (newExclude: traceFilterState) => {
+    // Selections carry a single exclude level, so never persist a nested one
     let exclude = TraceBooleanLogicGenerator.isEmptyTraceFields(newExclude)
       ? None
-      : Some(newExclude)
+      : Some({...newExclude, exclude: ?None})
     onFilterChange({...filterState, ?exclude})
   }
 

--- a/src/TransactionBooleanLogicGenerator.res
+++ b/src/TransactionBooleanLogicGenerator.res
@@ -1,6 +1,27 @@
 type transactionFilterState = QueryStructure.transactionSelection
 
-let generateEnglishDescription = (filterState: transactionFilterState) => {
+// True when the filter's own fields are empty, ignoring any exclude filter.
+let isEmptyTransactionFields = (filterState: transactionFilterState) => {
+  let {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList} = filterState
+  Array.length(from_->Option.getOr([])) === 0 &&
+  Array.length(to_->Option.getOr([])) === 0 &&
+  Array.length(sighash->Option.getOr([])) === 0 &&
+  Option.isNone(status) &&
+  Array.length(type_->Option.getOr([])) === 0 &&
+  Array.length(contractAddress->Option.getOr([])) === 0 &&
+  Array.length(hash->Option.getOr([])) === 0 &&
+  Array.length(authorizationList->Option.getOr([])) === 0
+}
+
+// Returns the exclude filter only when it actually has conditions.
+let excludeContent = (filterState: transactionFilterState): option<transactionFilterState> =>
+  switch filterState.exclude {
+  | Some(ex) if !isEmptyTransactionFields(ex) => Some(ex)
+  | _ => None
+  }
+
+// Description of the filter's own fields, "" when empty.
+let generateFieldsDescription = (filterState: transactionFilterState) => {
   let {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList} = filterState
   let fromArray = from_->Option.getOr([])
   let toArray = to_->Option.getOr([])
@@ -10,127 +31,125 @@ let generateEnglishDescription = (filterState: transactionFilterState) => {
   let hashArray = hash->Option.getOr([])
   let authArray = authorizationList->Option.getOr([])
 
-  let hasAnyFilter =
-    Array.length(fromArray) > 0 ||
-    Array.length(toArray) > 0 ||
-    Array.length(sighashArray) > 0 ||
-    Option.isSome(status) ||
-    Array.length(typeArray) > 0 ||
-    Array.length(contractAddressArray) > 0 ||
-    Array.length(hashArray) > 0 ||
-    Array.length(authArray) > 0
+  let parts = []
 
-  if !hasAnyFilter {
-    "No filters applied - will match all transactions"
-  } else {
-    let parts = []
-
-    // From condition
-    if Array.length(fromArray) > 0 {
-      let fromCondition = if Array.length(fromArray) === 1 {
-        `the sender address is ${Array.getUnsafe(fromArray, 0)}`
-      } else {
-        let fromList = Array.join(fromArray, " OR ")
-        `the sender address is ${fromList}`
-      }
-      parts->Array.push(fromCondition)->ignore
-    }
-
-    // To condition
-    if Array.length(toArray) > 0 {
-      let toCondition = if Array.length(toArray) === 1 {
-        `the recipient address is ${Array.getUnsafe(toArray, 0)}`
-      } else {
-        let toList = Array.join(toArray, " OR ")
-        `the recipient address is ${toList}`
-      }
-      parts->Array.push(toCondition)->ignore
-    }
-
-    // Sighash condition
-    if Array.length(sighashArray) > 0 {
-      let sighashCondition = if Array.length(sighashArray) === 1 {
-        `the function signature is ${Array.getUnsafe(sighashArray, 0)}`
-      } else {
-        let sighashList = Array.join(sighashArray, " OR ")
-        `the function signature is ${sighashList}`
-      }
-      parts->Array.push(sighashCondition)->ignore
-    }
-
-    // Status condition
-    switch status {
-    | Some(s) =>
-      let statusText = s === 1 ? "successful" : "failed"
-      parts->Array.push(`the transaction is ${statusText}`)->ignore
-    | None => ()
-    }
-
-    // Type condition
-    if Array.length(typeArray) > 0 {
-      let typeCondition = if Array.length(typeArray) === 1 {
-        `the transaction type is ${Int.toString(Array.getUnsafe(typeArray, 0))}`
-      } else {
-        let typeList = switch Array.length(typeArray) {
-        | 0 => ""
-        | 1 => Int.toString(Array.getUnsafe(typeArray, 0))
-        | 2 =>
-          Int.toString(Array.getUnsafe(typeArray, 0)) ++
-          " OR " ++
-          Int.toString(Array.getUnsafe(typeArray, 1))
-        | _ =>
-          let first = Int.toString(Array.getUnsafe(typeArray, 0))
-          let second = Int.toString(Array.getUnsafe(typeArray, 1))
-          let rest = Array.slice(typeArray, ~start=2)
-          let restStr = Array.reduce(rest, "", (acc, k) => acc ++ " OR " ++ Int.toString(k))
-          first ++ " OR " ++ second ++ restStr
-        }
-        `the transaction type is ${typeList}`
-      }
-      parts->Array.push(typeCondition)->ignore
-    }
-
-    // Contract address condition
-    if Array.length(contractAddressArray) > 0 {
-      let contractCondition = if Array.length(contractAddressArray) === 1 {
-        `the contract address is ${Array.getUnsafe(contractAddressArray, 0)}`
-      } else {
-        let contractList = Array.join(contractAddressArray, " OR ")
-        `the contract address is ${contractList}`
-      }
-      parts->Array.push(contractCondition)->ignore
-    }
-
-    // Hash condition
-    if Array.length(hashArray) > 0 {
-      let hashCondition = if Array.length(hashArray) === 1 {
-        `the transaction hash is ${Array.getUnsafe(hashArray, 0)}`
-      } else {
-        let hashList = Array.join(hashArray, " OR ")
-        `the transaction hash is ${hashList}`
-      }
-      parts->Array.push(hashCondition)->ignore
-    }
-
-    // Authorization list condition
-    if Array.length(authArray) > 0 {
-      let authCondition = if Array.length(authArray) === 1 {
-        `the authorization list includes ${Int.toString(Array.length(authArray))} authorization`
-      } else {
-        `the authorization list includes ${Int.toString(Array.length(authArray))} authorizations`
-      }
-      parts->Array.push(authCondition)->ignore
-    }
-
-    if Array.length(parts) > 0 {
-      `Match transactions where: ${Array.join(parts, " AND ")}`
+  // From condition
+  if Array.length(fromArray) > 0 {
+    let fromCondition = if Array.length(fromArray) === 1 {
+      `the sender address is ${Array.getUnsafe(fromArray, 0)}`
     } else {
+      let fromList = Array.join(fromArray, " OR ")
+      `the sender address is ${fromList}`
+    }
+    parts->Array.push(fromCondition)->ignore
+  }
+
+  // To condition
+  if Array.length(toArray) > 0 {
+    let toCondition = if Array.length(toArray) === 1 {
+      `the recipient address is ${Array.getUnsafe(toArray, 0)}`
+    } else {
+      let toList = Array.join(toArray, " OR ")
+      `the recipient address is ${toList}`
+    }
+    parts->Array.push(toCondition)->ignore
+  }
+
+  // Sighash condition
+  if Array.length(sighashArray) > 0 {
+    let sighashCondition = if Array.length(sighashArray) === 1 {
+      `the function signature is ${Array.getUnsafe(sighashArray, 0)}`
+    } else {
+      let sighashList = Array.join(sighashArray, " OR ")
+      `the function signature is ${sighashList}`
+    }
+    parts->Array.push(sighashCondition)->ignore
+  }
+
+  // Status condition
+  switch status {
+  | Some(s) =>
+    let statusText = s === 1 ? "successful" : "failed"
+    parts->Array.push(`the transaction is ${statusText}`)->ignore
+  | None => ()
+  }
+
+  // Type condition
+  if Array.length(typeArray) > 0 {
+    let typeCondition = if Array.length(typeArray) === 1 {
+      `the transaction type is ${Int.toString(Array.getUnsafe(typeArray, 0))}`
+    } else {
+      let typeList = switch Array.length(typeArray) {
+      | 0 => ""
+      | 1 => Int.toString(Array.getUnsafe(typeArray, 0))
+      | 2 =>
+        Int.toString(Array.getUnsafe(typeArray, 0)) ++
+        " OR " ++
+        Int.toString(Array.getUnsafe(typeArray, 1))
+      | _ =>
+        let first = Int.toString(Array.getUnsafe(typeArray, 0))
+        let second = Int.toString(Array.getUnsafe(typeArray, 1))
+        let rest = Array.slice(typeArray, ~start=2)
+        let restStr = Array.reduce(rest, "", (acc, k) => acc ++ " OR " ++ Int.toString(k))
+        first ++ " OR " ++ second ++ restStr
+      }
+      `the transaction type is ${typeList}`
+    }
+    parts->Array.push(typeCondition)->ignore
+  }
+
+  // Contract address condition
+  if Array.length(contractAddressArray) > 0 {
+    let contractCondition = if Array.length(contractAddressArray) === 1 {
+      `the contract address is ${Array.getUnsafe(contractAddressArray, 0)}`
+    } else {
+      let contractList = Array.join(contractAddressArray, " OR ")
+      `the contract address is ${contractList}`
+    }
+    parts->Array.push(contractCondition)->ignore
+  }
+
+  // Hash condition
+  if Array.length(hashArray) > 0 {
+    let hashCondition = if Array.length(hashArray) === 1 {
+      `the transaction hash is ${Array.getUnsafe(hashArray, 0)}`
+    } else {
+      let hashList = Array.join(hashArray, " OR ")
+      `the transaction hash is ${hashList}`
+    }
+    parts->Array.push(hashCondition)->ignore
+  }
+
+  // Authorization list condition
+  if Array.length(authArray) > 0 {
+    let authCondition = if Array.length(authArray) === 1 {
+      `the authorization list includes ${Int.toString(Array.length(authArray))} authorization`
+    } else {
+      `the authorization list includes ${Int.toString(Array.length(authArray))} authorizations`
+    }
+    parts->Array.push(authCondition)->ignore
+  }
+
+  Array.join(parts, " AND ")
+}
+
+let generateEnglishDescription = (filterState: transactionFilterState) => {
+  let include_ = generateFieldsDescription(filterState)
+  switch excludeContent(filterState) {
+  | Some(ex) =>
+    let exclude = generateFieldsDescription(ex)
+    `Match transactions where: ${BooleanLogicFormat.composeDescriptionWithNot(~include_, ~exclude)}`
+  | None =>
+    if include_ === "" {
       "No filters applied - will match all transactions"
+    } else {
+      `Match transactions where: ${include_}`
     }
   }
 }
 
-let generateBooleanHierarchy = (filterState: transactionFilterState) => {
+// Hierarchy of the filter's own fields, ignoring any exclude filter.
+let generateFieldsHierarchy = (filterState: transactionFilterState) => {
   let {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList} = filterState
   let fromArray = from_->Option.getOr([])
   let toArray = to_->Option.getOr([])
@@ -404,5 +423,19 @@ let generateBooleanHierarchy = (filterState: transactionFilterState) => {
     }
 
     Array.join(lines, "\n")
+  }
+}
+
+let generateBooleanHierarchy = (filterState: transactionFilterState) => {
+  switch excludeContent(filterState) {
+  | None => generateFieldsHierarchy(filterState)
+  | Some(ex) =>
+    let includeTree = isEmptyTransactionFields(filterState)
+      ? None
+      : Some(generateFieldsHierarchy(filterState))
+    BooleanLogicFormat.composeHierarchyWithNot(
+      ~includeTree,
+      ~excludeTree=generateFieldsHierarchy(ex),
+    )
   }
 }

--- a/src/TransactionFilter.res
+++ b/src/TransactionFilter.res
@@ -2,6 +2,484 @@ open QueryStructure
 
 type transactionFilterState = QueryStructure.transactionSelection
 
+let emptyTransactionFields: transactionFilterState = {
+  from_: None,
+  to_: None,
+  sighash: None,
+  status: None,
+  type_: None,
+  contractAddress: None,
+  hash: None,
+  authorizationList: None,
+}
+
+// Editor for a transaction filter's fields. Used for the filter itself and,
+// bound to `filterState.exclude`, for its exclusions.
+module FilterFields = {
+  @react.component
+  let make = (
+    ~filterState: transactionFilterState,
+    ~onFilterChange: transactionFilterState => unit,
+  ) => {
+    let (newFrom, setNewFrom) = React.useState(() => "")
+    let (newTo, setNewTo) = React.useState(() => "")
+    let (newSighash, setNewSighash) = React.useState(() => "")
+    let (newStatus, setNewStatus) = React.useState(() => "")
+    let (newType, setNewType) = React.useState(() => "")
+    let (newContractAddress, setNewContractAddress) = React.useState(() => "")
+    let (newHash, setNewHash) = React.useState(() => "")
+
+    let addFrom = () => {
+      if newFrom !== "" && newFrom->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          from_: Some(Array.concat(filterState.from_->Option.getOr([]), [newFrom])),
+        })
+        setNewFrom(_ => "")
+      }
+    }
+
+    let removeFrom = index => {
+      let currentArray = filterState.from_->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        from_: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addTo = () => {
+      if newTo !== "" && newTo->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          to_: Some(Array.concat(filterState.to_->Option.getOr([]), [newTo])),
+        })
+        setNewTo(_ => "")
+      }
+    }
+
+    let removeTo = index => {
+      let currentArray = filterState.to_->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        to_: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addSighash = () => {
+      if newSighash !== "" && newSighash->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          sighash: Some(Array.concat(filterState.sighash->Option.getOr([]), [newSighash])),
+        })
+        setNewSighash(_ => "")
+      }
+    }
+
+    let removeSighash = index => {
+      let currentArray = filterState.sighash->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        sighash: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let setStatus = () => {
+      switch Int.fromString(newStatus) {
+      | Some(status) =>
+        onFilterChange({...filterState, status: Some(status)})
+        setNewStatus(_ => "")
+      | None => ()
+      }
+    }
+
+    let clearStatus = () => {
+      onFilterChange({...filterState, status: None})
+    }
+
+    let addType = () => {
+      switch Int.fromString(newType) {
+      | Some(t) =>
+        onFilterChange({
+          ...filterState,
+          type_: Some(Array.concat(filterState.type_->Option.getOr([]), [t])),
+        })
+        setNewType(_ => "")
+      | None => ()
+      }
+    }
+
+    let removeType = index => {
+      let currentArray = filterState.type_->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        type_: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addContractAddress = () => {
+      if newContractAddress !== "" && newContractAddress->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          contractAddress: Some(
+            Array.concat(filterState.contractAddress->Option.getOr([]), [newContractAddress]),
+          ),
+        })
+        setNewContractAddress(_ => "")
+      }
+    }
+
+    let removeContractAddress = index => {
+      let currentArray = filterState.contractAddress->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        contractAddress: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    let addHash = () => {
+      if newHash !== "" && newHash->String.startsWith("0x") {
+        onFilterChange({
+          ...filterState,
+          hash: Some(Array.concat(filterState.hash->Option.getOr([]), [newHash])),
+        })
+        setNewHash(_ => "")
+      }
+    }
+
+    let removeHash = index => {
+      let currentArray = filterState.hash->Option.getOr([])
+      let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
+      onFilterChange({
+        ...filterState,
+        hash: Array.length(newArray) > 0 ? Some(newArray) : None,
+      })
+    }
+
+    <>
+      // From Addresses
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"From Addresses"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <input
+            type_="text"
+            value={newFrom}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewFrom(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <button
+            onClick={_ => addFrom()}
+            disabled={String.length(newFrom) == 0 || !(newFrom->String.startsWith("0x"))}
+            className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {(
+              Array.length(filterState.from_->Option.getOr([])) > 0
+                ? "Add (via OR) From"
+                : "Add From"
+            )->React.string}
+          </button>
+        </div>
+        <div className="space-y-2">
+          {Array.mapWithIndex(filterState.from_->Option.getOr([]), (address, index) =>
+            <div
+              key={Int.toString(index)}
+              className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
+            >
+              <span className="text-sm font-mono text-gray-800"> {address->React.string} </span>
+              <button
+                onClick={_ => removeFrom(index)} className="text-red-600 hover:text-red-800 text-sm"
+              >
+                {"Remove"->React.string}
+              </button>
+            </div>
+          )->React.array}
+        </div>
+      </div>
+
+      // To Addresses
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"To Addresses"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <input
+            type_="text"
+            value={newTo}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewTo(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <button
+            onClick={_ => addTo()}
+            disabled={String.length(newTo) == 0 || !(newTo->String.startsWith("0x"))}
+            className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {(
+              Array.length(filterState.to_->Option.getOr([])) > 0 ? "Add (via OR) To" : "Add To"
+            )->React.string}
+          </button>
+        </div>
+        <div className="space-y-2">
+          {Array.mapWithIndex(filterState.to_->Option.getOr([]), (address, index) =>
+            <div
+              key={Int.toString(index)}
+              className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
+            >
+              <span className="text-sm font-mono text-gray-800"> {address->React.string} </span>
+              <button
+                onClick={_ => removeTo(index)} className="text-red-600 hover:text-red-800 text-sm"
+              >
+                {"Remove"->React.string}
+              </button>
+            </div>
+          )->React.array}
+        </div>
+      </div>
+
+      // Sighash
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Function Signatures (Sighash)"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <input
+            type_="text"
+            value={newSighash}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewSighash(_ => target["value"])
+            }}
+            placeholder="0xa9059cbb"
+            className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <button
+            onClick={_ => addSighash()}
+            disabled={String.length(newSighash) == 0 || !(newSighash->String.startsWith("0x"))}
+            className="px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {(
+              Array.length(filterState.sighash->Option.getOr([])) > 0
+                ? "Add (via OR) Sighash"
+                : "Add Sighash"
+            )->React.string}
+          </button>
+        </div>
+        <div className="space-y-2">
+          {Array.mapWithIndex(filterState.sighash->Option.getOr([]), (sighash, index) =>
+            <div
+              key={Int.toString(index)}
+              className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
+            >
+              <span className="text-sm font-mono text-gray-800"> {sighash->React.string} </span>
+              <button
+                onClick={_ => removeSighash(index)}
+                className="text-red-600 hover:text-red-800 text-sm"
+              >
+                {"Remove"->React.string}
+              </button>
+            </div>
+          )->React.array}
+        </div>
+      </div>
+
+      // Status
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Transaction Status"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <input
+            type_="number"
+            value={newStatus}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewStatus(_ => target["value"])
+            }}
+            placeholder="0 (failed) or 1 (success)"
+            className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <button
+            onClick={_ => setStatus()}
+            disabled={String.length(newStatus) == 0}
+            className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {"Set Status"->React.string}
+          </button>
+        </div>
+        {switch filterState.status {
+        | Some(status) =>
+          <div className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md">
+            <span className="text-sm font-mono text-gray-800">
+              {`Status: ${Int.toString(status)} (${status === 1
+                  ? "Success"
+                  : "Failed"})`->React.string}
+            </span>
+            <button
+              onClick={_ => clearStatus()} className="text-red-600 hover:text-red-800 text-sm"
+            >
+              {"Clear"->React.string}
+            </button>
+          </div>
+        | None => React.null
+        }}
+      </div>
+
+      // Type
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Transaction Type"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <input
+            type_="number"
+            value={newType}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewType(_ => target["value"])
+            }}
+            placeholder="0, 1, 2..."
+            className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <button
+            onClick={_ => addType()}
+            disabled={String.length(newType) == 0}
+            className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {(
+              Array.length(filterState.type_->Option.getOr([])) > 0
+                ? "Add (via OR) Type"
+                : "Add Type"
+            )->React.string}
+          </button>
+        </div>
+        <div className="space-y-2">
+          {Array.mapWithIndex(filterState.type_->Option.getOr([]), (t, index) =>
+            <div
+              key={Int.toString(index)}
+              className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
+            >
+              <span className="text-sm font-mono text-gray-800">
+                {Int.toString(t)->React.string}
+              </span>
+              <button
+                onClick={_ => removeType(index)} className="text-red-600 hover:text-red-800 text-sm"
+              >
+                {"Remove"->React.string}
+              </button>
+            </div>
+          )->React.array}
+        </div>
+      </div>
+
+      // Contract Address
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Contract Addresses"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <input
+            type_="text"
+            value={newContractAddress}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewContractAddress(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <button
+            onClick={_ => addContractAddress()}
+            disabled={String.length(newContractAddress) == 0 ||
+              !(newContractAddress->String.startsWith("0x"))}
+            className="px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {(
+              Array.length(filterState.contractAddress->Option.getOr([])) > 0
+                ? "Add (via OR) Contract"
+                : "Add Contract"
+            )->React.string}
+          </button>
+        </div>
+        <div className="space-y-2">
+          {Array.mapWithIndex(filterState.contractAddress->Option.getOr([]), (address, index) =>
+            <div
+              key={Int.toString(index)}
+              className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
+            >
+              <span className="text-sm font-mono text-gray-800"> {address->React.string} </span>
+              <button
+                onClick={_ => removeContractAddress(index)}
+                className="text-red-600 hover:text-red-800 text-sm"
+              >
+                {"Remove"->React.string}
+              </button>
+            </div>
+          )->React.array}
+        </div>
+      </div>
+
+      // Transaction Hashes
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          {"Transaction Hashes"->React.string}
+        </label>
+        <div className="flex space-x-2 mb-3">
+          <input
+            type_="text"
+            value={newHash}
+            onChange={e => {
+              let target = ReactEvent.Form.target(e)
+              setNewHash(_ => target["value"])
+            }}
+            placeholder="0x..."
+            className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          <button
+            onClick={_ => addHash()}
+            disabled={String.length(newHash) == 0 || !(newHash->String.startsWith("0x"))}
+            className="px-4 py-2 bg-amber-600 text-white text-sm font-medium rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {(
+              Array.length(filterState.hash->Option.getOr([])) > 0
+                ? "Add (via OR) Hash"
+                : "Add Hash"
+            )->React.string}
+          </button>
+        </div>
+        <div className="space-y-2">
+          {Array.mapWithIndex(filterState.hash->Option.getOr([]), (h, index) =>
+            <div
+              key={Int.toString(index)}
+              className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
+            >
+              <span className="text-sm font-mono text-gray-800 truncate"> {h->React.string} </span>
+              <button
+                onClick={_ => removeHash(index)}
+                className="text-red-600 hover:text-red-800 text-sm ml-2 shrink-0"
+              >
+                {"Remove"->React.string}
+              </button>
+            </div>
+          )->React.array}
+        </div>
+      </div>
+    </>
+  }
+}
+
 @react.component
 let make = (
   ~filterState: transactionFilterState,
@@ -11,71 +489,33 @@ let make = (
   ~isExpanded: bool,
   ~onToggleExpand,
 ) => {
-  let (newFrom, setNewFrom) = React.useState(() => "")
-  let (newTo, setNewTo) = React.useState(() => "")
-  let (newSighash, setNewSighash) = React.useState(() => "")
-  let (newStatus, setNewStatus) = React.useState(() => "")
-  let (newType, setNewType) = React.useState(() => "")
-  let (newContractAddress, setNewContractAddress) = React.useState(() => "")
-  let (newHash, setNewHash) = React.useState(() => "")
-
   // Example filter states
   let eip7702Example: transactionFilterState = {
-    from_: None,
-    to_: None,
-    sighash: None,
-    status: None,
+    ...emptyTransactionFields,
     type_: Some([4]),
-    contractAddress: None,
-    hash: None,
-    authorizationList: None,
   }
 
   let failedTransactionsExample: transactionFilterState = {
-    from_: None,
-    to_: None,
-    sighash: None,
+    ...emptyTransactionFields,
     status: Some(0),
-    type_: None,
-    contractAddress: None,
-    hash: None,
-    authorizationList: None,
   }
 
   let transferCallExample: transactionFilterState = {
-    from_: None,
-    to_: None,
+    ...emptyTransactionFields,
     sighash: Some(["0xa9059cbb"]),
-    status: None,
-    type_: None,
-    contractAddress: None,
-    hash: None,
-    authorizationList: None,
   }
 
   let approveCallExample: transactionFilterState = {
-    from_: None,
-    to_: None,
+    ...emptyTransactionFields,
     sighash: Some(["0x095ea7b3"]),
-    status: None,
-    type_: None,
-    contractAddress: None,
-    hash: None,
-    authorizationList: None,
   }
 
   let lookupByHashExample: transactionFilterState = {
-    from_: None,
-    to_: None,
-    sighash: None,
-    status: None,
-    type_: None,
-    contractAddress: None,
+    ...emptyTransactionFields,
     hash: Some([
       "0x653a4532b6daf38b36e26794be5c27da1253811cfb1b422159232fd1aed68e40",
       "0x45b366153d0b2decc91c1fef8b5dc9c4bb0a0d1d2d01daa4bbd26d06029b6ebc",
     ]),
-    authorizationList: None,
   }
 
   let setEip7702Example = () => {
@@ -98,155 +538,24 @@ let make = (
     onFilterChange(lookupByHashExample)
   }
 
-  let addFrom = () => {
-    if newFrom !== "" && newFrom->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        from_: Some(Array.concat(filterState.from_->Option.getOr([]), [newFrom])),
-      })
-      setNewFrom(_ => "")
-    }
-  }
-
-  let removeFrom = index => {
-    let currentArray = filterState.from_->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      from_: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addTo = () => {
-    if newTo !== "" && newTo->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        to_: Some(Array.concat(filterState.to_->Option.getOr([]), [newTo])),
-      })
-      setNewTo(_ => "")
-    }
-  }
-
-  let removeTo = index => {
-    let currentArray = filterState.to_->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      to_: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addSighash = () => {
-    if newSighash !== "" && newSighash->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        sighash: Some(Array.concat(filterState.sighash->Option.getOr([]), [newSighash])),
-      })
-      setNewSighash(_ => "")
-    }
-  }
-
-  let removeSighash = index => {
-    let currentArray = filterState.sighash->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      sighash: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let setStatus = () => {
-    switch Int.fromString(newStatus) {
-    | Some(status) =>
-      onFilterChange({...filterState, status: Some(status)})
-      setNewStatus(_ => "")
-    | None => ()
-    }
-  }
-
-  let clearStatus = () => {
-    onFilterChange({...filterState, status: None})
-  }
-
-  let addType = () => {
-    switch Int.fromString(newType) {
-    | Some(t) =>
-      onFilterChange({
-        ...filterState,
-        type_: Some(Array.concat(filterState.type_->Option.getOr([]), [t])),
-      })
-      setNewType(_ => "")
-    | None => ()
-    }
-  }
-
-  let removeType = index => {
-    let currentArray = filterState.type_->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      type_: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addContractAddress = () => {
-    if newContractAddress !== "" && newContractAddress->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        contractAddress: Some(
-          Array.concat(filterState.contractAddress->Option.getOr([]), [newContractAddress]),
-        ),
-      })
-      setNewContractAddress(_ => "")
-    }
-  }
-
-  let removeContractAddress = index => {
-    let currentArray = filterState.contractAddress->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      contractAddress: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let addHash = () => {
-    if newHash !== "" && newHash->String.startsWith("0x") {
-      onFilterChange({
-        ...filterState,
-        hash: Some(Array.concat(filterState.hash->Option.getOr([]), [newHash])),
-      })
-      setNewHash(_ => "")
-    }
-  }
-
-  let removeHash = index => {
-    let currentArray = filterState.hash->Option.getOr([])
-    let newArray = Belt.Array.keepWithIndex(currentArray, (_, i) => i !== index)
-    onFilterChange({
-      ...filterState,
-      hash: Array.length(newArray) > 0 ? Some(newArray) : None,
-    })
-  }
-
-  let _transactionSelectionToStruct = (): option<transactionSelection> => {
-    Some(filterState)
+  let onExcludeChange = (newExclude: transactionFilterState) => {
+    let exclude = TransactionBooleanLogicGenerator.isEmptyTransactionFields(newExclude)
+      ? None
+      : Some(newExclude)
+    onFilterChange({...filterState, ?exclude})
   }
 
   let generateEnglishDescription = () => {
-    TransactionBooleanLogicGenerator.generateEnglishDescription(
-      (filterState :> TransactionBooleanLogicGenerator.transactionFilterState),
-    )
+    TransactionBooleanLogicGenerator.generateEnglishDescription(filterState)
   }
 
   let generateBooleanHierarchy = () => {
-    TransactionBooleanLogicGenerator.generateBooleanHierarchy(
-      (filterState :> TransactionBooleanLogicGenerator.transactionFilterState),
-    )
+    TransactionBooleanLogicGenerator.generateBooleanHierarchy(filterState)
   }
 
-  let generateCodeBlock = () => {
-    let {from_, to_, sighash, status, type_, contractAddress, hash} = filterState
+  // Pretty-printed JSON parts for a filter's own fields, indented by two spaces
+  let generateFieldParts = (state: transactionFilterState) => {
+    let {from_, to_, sighash, status, type_, contractAddress, hash} = state
 
     let fromStr = switch from_ {
     | Some(fromArray) if Array.length(fromArray) > 0 => {
@@ -319,16 +628,30 @@ let make = (
     | _ => ""
     }
 
-    let parts =
-      [
-        fromStr,
-        toStr,
-        sighashStr,
-        statusStr,
-        typeStr,
-        contractAddressStr,
-        hashStr,
-      ]->Array.filterMap(str => str !== "" ? Some(str) : None)
+    [
+      fromStr,
+      toStr,
+      sighashStr,
+      statusStr,
+      typeStr,
+      contractAddressStr,
+      hashStr,
+    ]->Array.filterMap(str => str !== "" ? Some(str) : None)
+  }
+
+  let generateCodeBlock = () => {
+    let parts = generateFieldParts(filterState)
+    let parts = switch TransactionBooleanLogicGenerator.excludeContent(filterState) {
+    | Some(ex) =>
+      let excludeParts = generateFieldParts(ex)->Array.map(part =>
+        part
+        ->String.split("\n")
+        ->Array.map(line => `  ${line}`)
+        ->Array.join("\n")
+      )
+      Array.concat(parts, [`  "exclude": {\n${Array.join(excludeParts, ",\n")}\n  }`])
+    | None => parts
+    }
     if Array.length(parts) > 0 {
       `{\n${Array.join(parts, ",\n")}\n}`
     } else {
@@ -336,14 +659,9 @@ let make = (
     }
   }
 
+  let hasExclusions = TransactionBooleanLogicGenerator.excludeContent(filterState)->Option.isSome
   let hasFilters =
-    Array.length(filterState.from_->Option.getOr([])) > 0 ||
-    Array.length(filterState.to_->Option.getOr([])) > 0 ||
-    Array.length(filterState.sighash->Option.getOr([])) > 0 ||
-    Option.isSome(filterState.status) ||
-    Array.length(filterState.type_->Option.getOr([])) > 0 ||
-    Array.length(filterState.contractAddress->Option.getOr([])) > 0 ||
-    Array.length(filterState.hash->Option.getOr([])) > 0
+    !TransactionBooleanLogicGenerator.isEmptyTransactionFields(filterState) || hasExclusions
 
   <div
     className="relative bg-white rounded-xl border border-slate-200 shadow-sm transition-all w-full"
@@ -432,326 +750,14 @@ let make = (
             </button>
           </div>
 
-          // From Addresses
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"From Addresses"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <input
-                type_="text"
-                value={newFrom}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewFrom(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <button
-                onClick={_ => addFrom()}
-                disabled={String.length(newFrom) == 0 || !(newFrom->String.startsWith("0x"))}
-                className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {(
-                  Array.length(filterState.from_->Option.getOr([])) > 0
-                    ? "Add (via OR) From"
-                    : "Add From"
-                )->React.string}
-              </button>
-            </div>
-            <div className="space-y-2">
-              {Array.mapWithIndex(filterState.from_->Option.getOr([]), (address, index) =>
-                <div
-                  key={Int.toString(index)}
-                  className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
-                >
-                  <span className="text-sm font-mono text-gray-800"> {address->React.string} </span>
-                  <button
-                    onClick={_ => removeFrom(index)}
-                    className="text-red-600 hover:text-red-800 text-sm"
-                  >
-                    {"Remove"->React.string}
-                  </button>
-                </div>
-              )->React.array}
-            </div>
-          </div>
+          <FilterFields filterState onFilterChange />
 
-          // To Addresses
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"To Addresses"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <input
-                type_="text"
-                value={newTo}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewTo(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <button
-                onClick={_ => addTo()}
-                disabled={String.length(newTo) == 0 || !(newTo->String.startsWith("0x"))}
-                className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {(
-                  Array.length(filterState.to_->Option.getOr([])) > 0 ? "Add (via OR) To" : "Add To"
-                )->React.string}
-              </button>
-            </div>
-            <div className="space-y-2">
-              {Array.mapWithIndex(filterState.to_->Option.getOr([]), (address, index) =>
-                <div
-                  key={Int.toString(index)}
-                  className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
-                >
-                  <span className="text-sm font-mono text-gray-800"> {address->React.string} </span>
-                  <button
-                    onClick={_ => removeTo(index)}
-                    className="text-red-600 hover:text-red-800 text-sm"
-                  >
-                    {"Remove"->React.string}
-                  </button>
-                </div>
-              )->React.array}
-            </div>
-          </div>
-
-          // Sighash
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Function Signatures (Sighash)"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <input
-                type_="text"
-                value={newSighash}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewSighash(_ => target["value"])
-                }}
-                placeholder="0xa9059cbb"
-                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <button
-                onClick={_ => addSighash()}
-                disabled={String.length(newSighash) == 0 || !(newSighash->String.startsWith("0x"))}
-                className="px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {(
-                  Array.length(filterState.sighash->Option.getOr([])) > 0
-                    ? "Add (via OR) Sighash"
-                    : "Add Sighash"
-                )->React.string}
-              </button>
-            </div>
-            <div className="space-y-2">
-              {Array.mapWithIndex(filterState.sighash->Option.getOr([]), (sighash, index) =>
-                <div
-                  key={Int.toString(index)}
-                  className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
-                >
-                  <span className="text-sm font-mono text-gray-800"> {sighash->React.string} </span>
-                  <button
-                    onClick={_ => removeSighash(index)}
-                    className="text-red-600 hover:text-red-800 text-sm"
-                  >
-                    {"Remove"->React.string}
-                  </button>
-                </div>
-              )->React.array}
-            </div>
-          </div>
-
-          // Status
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Transaction Status"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <input
-                type_="number"
-                value={newStatus}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewStatus(_ => target["value"])
-                }}
-                placeholder="0 (failed) or 1 (success)"
-                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <button
-                onClick={_ => setStatus()}
-                disabled={String.length(newStatus) == 0}
-                className="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {"Set Status"->React.string}
-              </button>
-            </div>
-            {switch filterState.status {
-            | Some(status) =>
-              <div className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md">
-                <span className="text-sm font-mono text-gray-800">
-                  {`Status: ${Int.toString(status)} (${status === 1
-                      ? "Success"
-                      : "Failed"})`->React.string}
-                </span>
-                <button
-                  onClick={_ => clearStatus()} className="text-red-600 hover:text-red-800 text-sm"
-                >
-                  {"Clear"->React.string}
-                </button>
-              </div>
-            | None => React.null
-            }}
-          </div>
-
-          // Type
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Transaction Type"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <input
-                type_="number"
-                value={newType}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewType(_ => target["value"])
-                }}
-                placeholder="0, 1, 2..."
-                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <button
-                onClick={_ => addType()}
-                disabled={String.length(newType) == 0}
-                className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {(
-                  Array.length(filterState.type_->Option.getOr([])) > 0
-                    ? "Add (via OR) Type"
-                    : "Add Type"
-                )->React.string}
-              </button>
-            </div>
-            <div className="space-y-2">
-              {Array.mapWithIndex(filterState.type_->Option.getOr([]), (t, index) =>
-                <div
-                  key={Int.toString(index)}
-                  className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
-                >
-                  <span className="text-sm font-mono text-gray-800">
-                    {Int.toString(t)->React.string}
-                  </span>
-                  <button
-                    onClick={_ => removeType(index)}
-                    className="text-red-600 hover:text-red-800 text-sm"
-                  >
-                    {"Remove"->React.string}
-                  </button>
-                </div>
-              )->React.array}
-            </div>
-          </div>
-
-          // Contract Address
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Contract Addresses"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <input
-                type_="text"
-                value={newContractAddress}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewContractAddress(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <button
-                onClick={_ => addContractAddress()}
-                disabled={String.length(newContractAddress) == 0 ||
-                  !(newContractAddress->String.startsWith("0x"))}
-                className="px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {(
-                  Array.length(filterState.contractAddress->Option.getOr([])) > 0
-                    ? "Add (via OR) Contract"
-                    : "Add Contract"
-                )->React.string}
-              </button>
-            </div>
-            <div className="space-y-2">
-              {Array.mapWithIndex(filterState.contractAddress->Option.getOr([]), (address, index) =>
-                <div
-                  key={Int.toString(index)}
-                  className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
-                >
-                  <span className="text-sm font-mono text-gray-800"> {address->React.string} </span>
-                  <button
-                    onClick={_ => removeContractAddress(index)}
-                    className="text-red-600 hover:text-red-800 text-sm"
-                  >
-                    {"Remove"->React.string}
-                  </button>
-                </div>
-              )->React.array}
-            </div>
-          </div>
-
-          // Transaction Hashes
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {"Transaction Hashes"->React.string}
-            </label>
-            <div className="flex space-x-2 mb-3">
-              <input
-                type_="text"
-                value={newHash}
-                onChange={e => {
-                  let target = ReactEvent.Form.target(e)
-                  setNewHash(_ => target["value"])
-                }}
-                placeholder="0x..."
-                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-              <button
-                onClick={_ => addHash()}
-                disabled={String.length(newHash) == 0 || !(newHash->String.startsWith("0x"))}
-                className="px-4 py-2 bg-amber-600 text-white text-sm font-medium rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {(
-                  Array.length(filterState.hash->Option.getOr([])) > 0
-                    ? "Add (via OR) Hash"
-                    : "Add Hash"
-                )->React.string}
-              </button>
-            </div>
-            <div className="space-y-2">
-              {Array.mapWithIndex(filterState.hash->Option.getOr([]), (h, index) =>
-                <div
-                  key={Int.toString(index)}
-                  className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
-                >
-                  <span className="text-sm font-mono text-gray-800 truncate">
-                    {h->React.string}
-                  </span>
-                  <button
-                    onClick={_ => removeHash(index)}
-                    className="text-red-600 hover:text-red-800 text-sm ml-2 shrink-0"
-                  >
-                    {"Remove"->React.string}
-                  </button>
-                </div>
-              )->React.array}
-            </div>
-          </div>
+          <ExcludeSection entityNamePlural="Transactions" hasExclusions>
+            <FilterFields
+              filterState={filterState.exclude->Option.getOr(emptyTransactionFields)}
+              onFilterChange={onExcludeChange}
+            />
+          </ExcludeSection>
 
           // English Description and Boolean Logic
           <div className="mt-6">

--- a/src/TransactionFilter.res
+++ b/src/TransactionFilter.res
@@ -539,9 +539,10 @@ let make = (
   }
 
   let onExcludeChange = (newExclude: transactionFilterState) => {
+    // Selections carry a single exclude level, so never persist a nested one
     let exclude = TransactionBooleanLogicGenerator.isEmptyTransactionFields(newExclude)
       ? None
-      : Some(newExclude)
+      : Some({...newExclude, exclude: ?None})
     onFilterChange({...filterState, ?exclude})
   }
 

--- a/src/UrlEncoder.res
+++ b/src/UrlEncoder.res
@@ -121,7 +121,10 @@ let deserializeTraceField = (str: string): option<traceField> => {
   )
 }
 
-let rec serializeLogSelectionJson = (log: logSelection): JSON.t => {
+// Selections carry at most one level of exclude (a nested exclude is not
+// representable in the server's Selection<T> type), so exclude filters are
+// encoded and decoded fields-only.
+let serializeLogFieldsJson = (log: logSelection): array<(string, JSON.t)> => {
   let addressJson = switch log.address {
   | Some(addresses) => JSON.Encode.array(addresses->Array.map(JSON.Encode.string))
   | None => JSON.Encode.null
@@ -133,15 +136,26 @@ let rec serializeLogSelectionJson = (log: logSelection): JSON.t => {
     )
   | None => JSON.Encode.null
   }
-  let fields = [("address", addressJson), ("topics", topicsJson)]
+  [("address", addressJson), ("topics", topicsJson)]
+}
+
+let serializeLogSelectionJson = (log: logSelection): JSON.t => {
+  let fields = serializeLogFieldsJson(log)
   let fields = switch log.exclude {
-  | Some(ex) => Array.concat(fields, [("exclude", serializeLogSelectionJson(ex))])
+  | Some(ex) =>
+    Array.concat(
+      fields,
+      [("exclude", JSON.Encode.object(Dict.fromArray(serializeLogFieldsJson(ex))))],
+    )
   | None => fields
   }
   JSON.Encode.object(Dict.fromArray(fields))
 }
 
-let rec serializeTransactionSelectionJson = (transaction: transactionSelection): JSON.t => {
+let serializeTransactionFieldsJson = (transaction: transactionSelection): array<(
+  string,
+  JSON.t,
+)> => {
   let fromJson = switch transaction.from_ {
   | Some(froms) => JSON.Encode.array(froms->Array.map(JSON.Encode.string))
   | None => JSON.Encode.null
@@ -190,7 +204,7 @@ let rec serializeTransactionSelectionJson = (transaction: transactionSelection):
     )
   | None => JSON.Encode.null
   }
-  let fields = [
+  [
     ("from_", fromJson),
     ("to_", toJson),
     ("sighash", sighashJson),
@@ -200,14 +214,22 @@ let rec serializeTransactionSelectionJson = (transaction: transactionSelection):
     ("hash", hashJson),
     ("authorizationList", authorizationListJson),
   ]
+}
+
+let serializeTransactionSelectionJson = (transaction: transactionSelection): JSON.t => {
+  let fields = serializeTransactionFieldsJson(transaction)
   let fields = switch transaction.exclude {
-  | Some(ex) => Array.concat(fields, [("exclude", serializeTransactionSelectionJson(ex))])
+  | Some(ex) =>
+    Array.concat(
+      fields,
+      [("exclude", JSON.Encode.object(Dict.fromArray(serializeTransactionFieldsJson(ex))))],
+    )
   | None => fields
   }
   JSON.Encode.object(Dict.fromArray(fields))
 }
 
-let rec serializeBlockSelectionJson = (block: blockSelection): JSON.t => {
+let serializeBlockFieldsJson = (block: blockSelection): array<(string, JSON.t)> => {
   let hashJson = switch block.hash {
   | Some(hashes) => JSON.Encode.array(hashes->Array.map(JSON.Encode.string))
   | None => JSON.Encode.null
@@ -216,9 +238,17 @@ let rec serializeBlockSelectionJson = (block: blockSelection): JSON.t => {
   | Some(miners) => JSON.Encode.array(miners->Array.map(JSON.Encode.string))
   | None => JSON.Encode.null
   }
-  let fields = [("hash", hashJson), ("miner", minerJson)]
+  [("hash", hashJson), ("miner", minerJson)]
+}
+
+let serializeBlockSelectionJson = (block: blockSelection): JSON.t => {
+  let fields = serializeBlockFieldsJson(block)
   let fields = switch block.exclude {
-  | Some(ex) => Array.concat(fields, [("exclude", serializeBlockSelectionJson(ex))])
+  | Some(ex) =>
+    Array.concat(
+      fields,
+      [("exclude", JSON.Encode.object(Dict.fromArray(serializeBlockFieldsJson(ex))))],
+    )
   | None => fields
   }
   JSON.Encode.object(Dict.fromArray(fields))
@@ -345,7 +375,7 @@ let serializeUrlState = (state: urlState): string => {
   JSON.stringify(json)
 }
 
-let rec decodeLogSelection = (log: dict<JSON.t>): logSelection => {
+let decodeLogSelectionFields = (log: dict<JSON.t>): logSelection => {
   let address = switch Dict.get(log, "address") {
   | Some(value) =>
     switch JSON.Decode.null(value) {
@@ -381,18 +411,24 @@ let rec decodeLogSelection = (log: dict<JSON.t>): logSelection => {
     }
   | None => None
   }
+  {address, topics}
+}
+
+let decodeLogSelection = (log: dict<JSON.t>): logSelection => {
+  let fields = decodeLogSelectionFields(log)
+  // Fields-only: a nested exclude has no server-side meaning, so it is dropped.
   let exclude = switch Dict.get(log, "exclude") {
   | Some(value) =>
     switch JSON.Decode.object(value) {
-    | Some(excludeObj) => Some(decodeLogSelection(excludeObj))
+    | Some(excludeObj) => Some(decodeLogSelectionFields(excludeObj))
     | None => None
     }
   | None => None
   }
-  {address, topics, ?exclude}
+  {...fields, ?exclude}
 }
 
-let rec decodeTransactionSelection = (transaction: dict<JSON.t>): transactionSelection => {
+let decodeTransactionSelectionFields = (transaction: dict<JSON.t>): transactionSelection => {
   let from_ = switch Dict.get(transaction, "from_") {
   | Some(value) =>
     switch JSON.Decode.null(value) {
@@ -539,18 +575,24 @@ let rec decodeTransactionSelection = (transaction: dict<JSON.t>): transactionSel
     }
   | None => None
   }
+  {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList}
+}
+
+let decodeTransactionSelection = (transaction: dict<JSON.t>): transactionSelection => {
+  let fields = decodeTransactionSelectionFields(transaction)
+  // Fields-only: a nested exclude has no server-side meaning, so it is dropped.
   let exclude = switch Dict.get(transaction, "exclude") {
   | Some(value) =>
     switch JSON.Decode.object(value) {
-    | Some(excludeObj) => Some(decodeTransactionSelection(excludeObj))
+    | Some(excludeObj) => Some(decodeTransactionSelectionFields(excludeObj))
     | None => None
     }
   | None => None
   }
-  {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList, ?exclude}
+  {...fields, ?exclude}
 }
 
-let rec decodeBlockSelection = (block: dict<JSON.t>): blockSelection => {
+let decodeBlockSelectionFields = (block: dict<JSON.t>): blockSelection => {
   let hash = switch Dict.get(block, "hash") {
   | Some(value) =>
     switch JSON.Decode.null(value) {
@@ -575,15 +617,21 @@ let rec decodeBlockSelection = (block: dict<JSON.t>): blockSelection => {
     }
   | None => None
   }
+  {hash, miner}
+}
+
+let decodeBlockSelection = (block: dict<JSON.t>): blockSelection => {
+  let fields = decodeBlockSelectionFields(block)
+  // Fields-only: a nested exclude has no server-side meaning, so it is dropped.
   let exclude = switch Dict.get(block, "exclude") {
   | Some(value) =>
     switch JSON.Decode.object(value) {
-    | Some(excludeObj) => Some(decodeBlockSelection(excludeObj))
+    | Some(excludeObj) => Some(decodeBlockSelectionFields(excludeObj))
     | None => None
     }
   | None => None
   }
-  {hash, miner, ?exclude}
+  {...fields, ?exclude}
 }
 
 let deserializeUrlState = (jsonString: string): option<urlState> => {

--- a/src/UrlEncoder.res
+++ b/src/UrlEncoder.res
@@ -121,6 +121,109 @@ let deserializeTraceField = (str: string): option<traceField> => {
   )
 }
 
+let rec serializeLogSelectionJson = (log: logSelection): JSON.t => {
+  let addressJson = switch log.address {
+  | Some(addresses) => JSON.Encode.array(addresses->Array.map(JSON.Encode.string))
+  | None => JSON.Encode.null
+  }
+  let topicsJson = switch log.topics {
+  | Some(topics) =>
+    JSON.Encode.array(
+      topics->Array.map(topicArray => JSON.Encode.array(topicArray->Array.map(JSON.Encode.string))),
+    )
+  | None => JSON.Encode.null
+  }
+  let fields = [("address", addressJson), ("topics", topicsJson)]
+  let fields = switch log.exclude {
+  | Some(ex) => Array.concat(fields, [("exclude", serializeLogSelectionJson(ex))])
+  | None => fields
+  }
+  JSON.Encode.object(Dict.fromArray(fields))
+}
+
+let rec serializeTransactionSelectionJson = (transaction: transactionSelection): JSON.t => {
+  let fromJson = switch transaction.from_ {
+  | Some(froms) => JSON.Encode.array(froms->Array.map(JSON.Encode.string))
+  | None => JSON.Encode.null
+  }
+  let toJson = switch transaction.to_ {
+  | Some(tos) => JSON.Encode.array(tos->Array.map(JSON.Encode.string))
+  | None => JSON.Encode.null
+  }
+  let sighashJson = switch transaction.sighash {
+  | Some(sighashes) => JSON.Encode.array(sighashes->Array.map(JSON.Encode.string))
+  | None => JSON.Encode.null
+  }
+  let statusJson = switch transaction.status {
+  | Some(status) => JSON.Encode.float(Int.toFloat(status))
+  | None => JSON.Encode.null
+  }
+  let typeJson = switch transaction.type_ {
+  | Some(types) => JSON.Encode.array(types->Array.map(t => JSON.Encode.float(Int.toFloat(t))))
+  | None => JSON.Encode.null
+  }
+  let contractAddressJson = switch transaction.contractAddress {
+  | Some(addresses) => JSON.Encode.array(addresses->Array.map(JSON.Encode.string))
+  | None => JSON.Encode.null
+  }
+  let hashJson = switch transaction.hash {
+  | Some(hashes) => JSON.Encode.array(hashes->Array.map(JSON.Encode.string))
+  | None => JSON.Encode.null
+  }
+  let authorizationListJson = switch transaction.authorizationList {
+  | Some(authorizations) =>
+    JSON.Encode.array(
+      authorizations->Array.map(auth => {
+        let authChainIdJson = switch auth.chainId {
+        | Some(chainIds) =>
+          JSON.Encode.array(chainIds->Array.map(chainId => JSON.Encode.float(Int.toFloat(chainId))))
+        | None => JSON.Encode.null
+        }
+        let authAddressJson = switch auth.address {
+        | Some(addresses) => JSON.Encode.array(addresses->Array.map(JSON.Encode.string))
+        | None => JSON.Encode.null
+        }
+        JSON.Encode.object(
+          Dict.fromArray([("chainId", authChainIdJson), ("address", authAddressJson)]),
+        )
+      }),
+    )
+  | None => JSON.Encode.null
+  }
+  let fields = [
+    ("from_", fromJson),
+    ("to_", toJson),
+    ("sighash", sighashJson),
+    ("status", statusJson),
+    ("type_", typeJson),
+    ("contractAddress", contractAddressJson),
+    ("hash", hashJson),
+    ("authorizationList", authorizationListJson),
+  ]
+  let fields = switch transaction.exclude {
+  | Some(ex) => Array.concat(fields, [("exclude", serializeTransactionSelectionJson(ex))])
+  | None => fields
+  }
+  JSON.Encode.object(Dict.fromArray(fields))
+}
+
+let rec serializeBlockSelectionJson = (block: blockSelection): JSON.t => {
+  let hashJson = switch block.hash {
+  | Some(hashes) => JSON.Encode.array(hashes->Array.map(JSON.Encode.string))
+  | None => JSON.Encode.null
+  }
+  let minerJson = switch block.miner {
+  | Some(miners) => JSON.Encode.array(miners->Array.map(JSON.Encode.string))
+  | None => JSON.Encode.null
+  }
+  let fields = [("hash", hashJson), ("miner", minerJson)]
+  let fields = switch block.exclude {
+  | Some(ex) => Array.concat(fields, [("exclude", serializeBlockSelectionJson(ex))])
+  | None => fields
+  }
+  JSON.Encode.object(Dict.fromArray(fields))
+}
+
 let serializeUrlState = (state: urlState): string => {
   let json = JSON.Encode.object(
     Dict.fromArray([
@@ -169,27 +272,7 @@ let serializeUrlState = (state: urlState): string => {
             (
               "logs",
               switch state.query.logs {
-              | Some(logs) =>
-                JSON.Encode.array(
-                  logs->Array.map(log => {
-                    let addressJson = switch log.address {
-                    | Some(addresses) => JSON.Encode.array(addresses->Array.map(JSON.Encode.string))
-                    | None => JSON.Encode.null
-                    }
-                    let topicsJson = switch log.topics {
-                    | Some(topics) =>
-                      JSON.Encode.array(
-                        topics->Array.map(topicArray =>
-                          JSON.Encode.array(topicArray->Array.map(JSON.Encode.string))
-                        ),
-                      )
-                    | None => JSON.Encode.null
-                    }
-                    JSON.Encode.object(
-                      Dict.fromArray([("address", addressJson), ("topics", topicsJson)]),
-                    )
-                  }),
-                )
+              | Some(logs) => JSON.Encode.array(logs->Array.map(serializeLogSelectionJson))
               | None => JSON.Encode.null
               },
             ),
@@ -197,99 +280,14 @@ let serializeUrlState = (state: urlState): string => {
               "transactions",
               switch state.query.transactions {
               | Some(transactions) =>
-                JSON.Encode.array(
-                  transactions->Array.map(transaction => {
-                    let fromJson = switch transaction.from_ {
-                    | Some(froms) => JSON.Encode.array(froms->Array.map(JSON.Encode.string))
-                    | None => JSON.Encode.null
-                    }
-                    let toJson = switch transaction.to_ {
-                    | Some(tos) => JSON.Encode.array(tos->Array.map(JSON.Encode.string))
-                    | None => JSON.Encode.null
-                    }
-                    let sighashJson = switch transaction.sighash {
-                    | Some(sighashes) => JSON.Encode.array(sighashes->Array.map(JSON.Encode.string))
-                    | None => JSON.Encode.null
-                    }
-                    let statusJson = switch transaction.status {
-                    | Some(status) => JSON.Encode.float(Int.toFloat(status))
-                    | None => JSON.Encode.null
-                    }
-                    let typeJson = switch transaction.type_ {
-                    | Some(types) =>
-                      JSON.Encode.array(types->Array.map(t => JSON.Encode.float(Int.toFloat(t))))
-                    | None => JSON.Encode.null
-                    }
-                    let contractAddressJson = switch transaction.contractAddress {
-                    | Some(addresses) => JSON.Encode.array(addresses->Array.map(JSON.Encode.string))
-                    | None => JSON.Encode.null
-                    }
-                    let hashJson = switch transaction.hash {
-                    | Some(hashes) => JSON.Encode.array(hashes->Array.map(JSON.Encode.string))
-                    | None => JSON.Encode.null
-                    }
-                    let authorizationListJson = switch transaction.authorizationList {
-                    | Some(authorizations) =>
-                      JSON.Encode.array(
-                        authorizations->Array.map(auth => {
-                          let authChainIdJson = switch auth.chainId {
-                          | Some(chainIds) =>
-                            JSON.Encode.array(
-                              chainIds->Array.map(
-                                chainId => JSON.Encode.float(Int.toFloat(chainId)),
-                              ),
-                            )
-                          | None => JSON.Encode.null
-                          }
-                          let authAddressJson = switch auth.address {
-                          | Some(addresses) =>
-                            JSON.Encode.array(addresses->Array.map(JSON.Encode.string))
-                          | None => JSON.Encode.null
-                          }
-                          JSON.Encode.object(
-                            Dict.fromArray([
-                              ("chainId", authChainIdJson),
-                              ("address", authAddressJson),
-                            ]),
-                          )
-                        }),
-                      )
-                    | None => JSON.Encode.null
-                    }
-                    JSON.Encode.object(
-                      Dict.fromArray([
-                        ("from_", fromJson),
-                        ("to_", toJson),
-                        ("sighash", sighashJson),
-                        ("status", statusJson),
-                        ("type_", typeJson),
-                        ("contractAddress", contractAddressJson),
-                        ("hash", hashJson),
-                        ("authorizationList", authorizationListJson),
-                      ]),
-                    )
-                  }),
-                )
+                JSON.Encode.array(transactions->Array.map(serializeTransactionSelectionJson))
               | None => JSON.Encode.null
               },
             ),
             (
               "blocks",
               switch state.query.blocks {
-              | Some(blocks) =>
-                JSON.Encode.array(
-                  blocks->Array.map(block => {
-                    let hashJson = switch block.hash {
-                    | Some(hashes) => JSON.Encode.array(hashes->Array.map(JSON.Encode.string))
-                    | None => JSON.Encode.null
-                    }
-                    let minerJson = switch block.miner {
-                    | Some(miners) => JSON.Encode.array(miners->Array.map(JSON.Encode.string))
-                    | None => JSON.Encode.null
-                    }
-                    JSON.Encode.object(Dict.fromArray([("hash", hashJson), ("miner", minerJson)]))
-                  }),
-                )
+              | Some(blocks) => JSON.Encode.array(blocks->Array.map(serializeBlockSelectionJson))
               | None => JSON.Encode.null
               },
             ),
@@ -345,6 +343,247 @@ let serializeUrlState = (state: urlState): string => {
     ]),
   )
   JSON.stringify(json)
+}
+
+let rec decodeLogSelection = (log: dict<JSON.t>): logSelection => {
+  let address = switch Dict.get(log, "address") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(addresses) => Some(addresses->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let topics = switch Dict.get(log, "topics") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(topicsArray) => {
+          let decodedTopics =
+            topicsArray
+            ->Array.map(JSON.Decode.array)
+            ->Array.filterMap(x => x)
+            ->Array.map(topicArray =>
+              topicArray
+              ->Array.map(JSON.Decode.string)
+              ->Array.filterMap(x => x)
+            )
+          Some(decodedTopics)
+        }
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let exclude = switch Dict.get(log, "exclude") {
+  | Some(value) =>
+    switch JSON.Decode.object(value) {
+    | Some(excludeObj) => Some(decodeLogSelection(excludeObj))
+    | None => None
+    }
+  | None => None
+  }
+  {address, topics, ?exclude}
+}
+
+let rec decodeTransactionSelection = (transaction: dict<JSON.t>): transactionSelection => {
+  let from_ = switch Dict.get(transaction, "from_") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(froms) => Some(froms->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let to_ = switch Dict.get(transaction, "to_") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(tos) => Some(tos->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let sighash = switch Dict.get(transaction, "sighash") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(sighashes) => Some(sighashes->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let status = switch Dict.get(transaction, "status") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.float(value) {
+      | Some(num) => Some(Float.toInt(num))
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let type_ = switch Dict.get(transaction, "type_") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(types) =>
+        Some(
+          types
+          ->Array.map(JSON.Decode.float)
+          ->Array.filterMap(x => x)
+          ->Array.map(t => Float.toInt(t)),
+        )
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let contractAddress = switch Dict.get(transaction, "contractAddress") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(addresses) => Some(addresses->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let hash = switch Dict.get(transaction, "hash") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(hashes) => Some(hashes->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let authorizationList = switch Dict.get(transaction, "authorizationList") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(authorizations) => {
+          let decodedAuthorizations =
+            authorizations
+            ->Array.map(JSON.Decode.object)
+            ->Array.filterMap(x => x)
+            ->Array.map(auth => {
+              let chainId = switch Dict.get(auth, "chainId") {
+              | Some(value) =>
+                switch JSON.Decode.null(value) {
+                | Some(_) => None
+                | None =>
+                  switch JSON.Decode.array(value) {
+                  | Some(chainIds) =>
+                    Some(
+                      chainIds
+                      ->Array.map(JSON.Decode.float)
+                      ->Array.filterMap(x => x)
+                      ->Array.map(chainId => Float.toInt(chainId)),
+                    )
+                  | None => None
+                  }
+                }
+              | None => None
+              }
+              let address = switch Dict.get(auth, "address") {
+              | Some(value) =>
+                switch JSON.Decode.null(value) {
+                | Some(_) => None
+                | None =>
+                  switch JSON.Decode.array(value) {
+                  | Some(addresses) =>
+                    Some(
+                      addresses
+                      ->Array.map(JSON.Decode.string)
+                      ->Array.filterMap(x => x),
+                    )
+                  | None => None
+                  }
+                }
+              | None => None
+              }
+              {chainId, address}
+            })
+          Some(decodedAuthorizations)
+        }
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let exclude = switch Dict.get(transaction, "exclude") {
+  | Some(value) =>
+    switch JSON.Decode.object(value) {
+    | Some(excludeObj) => Some(decodeTransactionSelection(excludeObj))
+    | None => None
+    }
+  | None => None
+  }
+  {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList, ?exclude}
+}
+
+let rec decodeBlockSelection = (block: dict<JSON.t>): blockSelection => {
+  let hash = switch Dict.get(block, "hash") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(hashes) => Some(hashes->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let miner = switch Dict.get(block, "miner") {
+  | Some(value) =>
+    switch JSON.Decode.null(value) {
+    | Some(_) => None
+    | None =>
+      switch JSON.Decode.array(value) {
+      | Some(miners) => Some(miners->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
+      | None => None
+      }
+    }
+  | None => None
+  }
+  let exclude = switch Dict.get(block, "exclude") {
+  | Some(value) =>
+    switch JSON.Decode.object(value) {
+    | Some(excludeObj) => Some(decodeBlockSelection(excludeObj))
+    | None => None
+    }
+  | None => None
+  }
+  {hash, miner, ?exclude}
 }
 
 let deserializeUrlState = (jsonString: string): option<urlState> => {
@@ -456,45 +695,7 @@ let deserializeUrlState = (jsonString: string): option<urlState> => {
                     array
                     ->Array.map(JSON.Decode.object)
                     ->Array.filterMap(x => x)
-                    ->Array.map(log => {
-                      let address = switch Dict.get(log, "address") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(addresses) =>
-                            Some(addresses->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      let topics = switch Dict.get(log, "topics") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(topicsArray) => {
-                              let decodedTopics =
-                                topicsArray
-                                ->Array.map(JSON.Decode.array)
-                                ->Array.filterMap(x => x)
-                                ->Array.map(topicArray =>
-                                  topicArray
-                                  ->Array.map(JSON.Decode.string)
-                                  ->Array.filterMap(x => x)
-                                )
-                              Some(decodedTopics)
-                            }
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      {address, topics}
-                    })
+                    ->Array.map(decodeLogSelection)
                   Some(decodedLogs)
                 }
               | None => None
@@ -514,160 +715,7 @@ let deserializeUrlState = (jsonString: string): option<urlState> => {
                     array
                     ->Array.map(JSON.Decode.object)
                     ->Array.filterMap(x => x)
-                    ->Array.map(transaction => {
-                      let from_ = switch Dict.get(transaction, "from_") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(froms) =>
-                            Some(froms->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      let to_ = switch Dict.get(transaction, "to_") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(tos) =>
-                            Some(tos->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      let sighash = switch Dict.get(transaction, "sighash") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(sighashes) =>
-                            Some(sighashes->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      let status = switch Dict.get(transaction, "status") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.float(value) {
-                          | Some(num) => Some(Float.toInt(num))
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      let type_ = switch Dict.get(transaction, "type_") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(types) =>
-                            Some(
-                              types
-                              ->Array.map(JSON.Decode.float)
-                              ->Array.filterMap(x => x)
-                              ->Array.map(t => Float.toInt(t)),
-                            )
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      let contractAddress = switch Dict.get(transaction, "contractAddress") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(addresses) =>
-                            Some(addresses->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      let hash = switch Dict.get(transaction, "hash") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(hashes) =>
-                            Some(hashes->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      let authorizationList = switch Dict.get(transaction, "authorizationList") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(authorizations) => {
-                              let decodedAuthorizations =
-                                authorizations
-                                ->Array.map(JSON.Decode.object)
-                                ->Array.filterMap(x => x)
-                                ->Array.map(auth => {
-                                  let chainId = switch Dict.get(auth, "chainId") {
-                                  | Some(value) =>
-                                    switch JSON.Decode.null(value) {
-                                    | Some(_) => None
-                                    | None =>
-                                      switch JSON.Decode.array(value) {
-                                      | Some(chainIds) =>
-                                        Some(
-                                          chainIds
-                                          ->Array.map(JSON.Decode.float)
-                                          ->Array.filterMap(x => x)
-                                          ->Array.map(chainId => Float.toInt(chainId)),
-                                        )
-                                      | None => None
-                                      }
-                                    }
-                                  | None => None
-                                  }
-                                  let address = switch Dict.get(auth, "address") {
-                                  | Some(value) =>
-                                    switch JSON.Decode.null(value) {
-                                    | Some(_) => None
-                                    | None =>
-                                      switch JSON.Decode.array(value) {
-                                      | Some(addresses) =>
-                                        Some(
-                                          addresses
-                                          ->Array.map(JSON.Decode.string)
-                                          ->Array.filterMap(x => x),
-                                        )
-                                      | None => None
-                                      }
-                                    }
-                                  | None => None
-                                  }
-                                  {chainId, address}
-                                })
-                              Some(decodedAuthorizations)
-                            }
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      {from_, to_, sighash, status, type_, contractAddress, hash, authorizationList}
-                    })
+                    ->Array.map(decodeTransactionSelection)
                   Some(decodedTransactions)
                 }
               | None => None
@@ -687,35 +735,7 @@ let deserializeUrlState = (jsonString: string): option<urlState> => {
                     array
                     ->Array.map(JSON.Decode.object)
                     ->Array.filterMap(x => x)
-                    ->Array.map(block => {
-                      let hash = switch Dict.get(block, "hash") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(hashes) =>
-                            Some(hashes->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      let miner = switch Dict.get(block, "miner") {
-                      | Some(value) =>
-                        switch JSON.Decode.null(value) {
-                        | Some(_) => None
-                        | None =>
-                          switch JSON.Decode.array(value) {
-                          | Some(miners) =>
-                            Some(miners->Array.map(JSON.Decode.string)->Array.filterMap(x => x))
-                          | None => None
-                          }
-                        }
-                      | None => None
-                      }
-                      {hash, miner}
-                    })
+                    ->Array.map(decodeBlockSelection)
                   Some(decodedBlocks)
                 }
               | None => None

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,14 +1,18 @@
 import { ReactElement } from 'react';
 
 // Query structure types
+// `exclude` holds a filter of the same shape; matching rows are excluded from
+// the selection's results.
 export interface BlockSelection {
   hash?: string[];
   miner?: string[];
+  exclude?: BlockSelection;
 }
 
 export interface LogSelection {
   address?: string[];
   topics?: string[][];
+  exclude?: LogSelection;
 }
 
 export interface AuthorizationSelection {
@@ -24,6 +28,7 @@ export interface TransactionSelection {
   kind?: number[];
   contractAddress?: string[];
   authorizationList?: AuthorizationSelection[];
+  exclude?: TransactionSelection;
 }
 
 export interface TraceSelection {
@@ -34,6 +39,7 @@ export interface TraceSelection {
   rewardType?: string[];
   kind?: string[];
   sighash?: string[];
+  exclude?: TraceSelection;
 }
 
 export type BlockField =

--- a/src/query-builder/QueryStructure.res
+++ b/src/query-builder/QueryStructure.res
@@ -1,13 +1,19 @@
 // Selection types
+// Each selection can carry an optional `exclude` filter with the same shape as the
+// selection itself: a row matches when it matches the selection's own fields AND
+// does not match the exclude filter. The nested filter never carries its own
+// exclude. Mirrors `Selection<T>` in hypersync-net-types.
 
-type blockSelection = {
+type rec blockSelection = {
   hash: option<array<string>>,
   miner: option<array<string>>,
+  exclude?: blockSelection,
 }
 
-type logSelection = {
+type rec logSelection = {
   address: option<array<string>>,
   topics: option<array<array<string>>>,
+  exclude?: logSelection,
 }
 
 type authorizationSelection = {
@@ -15,7 +21,7 @@ type authorizationSelection = {
   address: option<array<string>>,
 }
 
-type transactionSelection = {
+type rec transactionSelection = {
   from_: option<array<string>>,
   to_: option<array<string>>,
   sighash: option<array<string>>,
@@ -24,9 +30,10 @@ type transactionSelection = {
   contractAddress: option<array<string>>,
   hash: option<array<string>>,
   authorizationList: option<array<authorizationSelection>>,
+  exclude?: transactionSelection,
 }
 
-type traceSelection = {
+type rec traceSelection = {
   from_: option<array<string>>,
   to_: option<array<string>>,
   address: option<array<string>>,
@@ -34,6 +41,7 @@ type traceSelection = {
   rewardType: option<array<string>>,
   type_: option<array<string>>,
   sighash: option<array<string>>,
+  exclude?: traceSelection,
 }
 
 // Field selection enums

--- a/tests/ExcludeFilters_test.res
+++ b/tests/ExcludeFilters_test.res
@@ -1,0 +1,268 @@
+open Test
+open QueryStructure
+
+// Tests for exclude filters: English descriptions, boolean hierarchies,
+// emptiness checks, and URL round-tripping.
+
+let emptyTransactionFields: transactionSelection = {
+  from_: None,
+  to_: None,
+  sighash: None,
+  status: None,
+  type_: None,
+  contractAddress: None,
+  hash: None,
+  authorizationList: None,
+}
+
+let emptyTraceFields: traceSelection = {
+  from_: None,
+  to_: None,
+  address: None,
+  callType: None,
+  rewardType: None,
+  type_: None,
+  sighash: None,
+}
+
+// Log filters
+
+test("log english description - include with exclude", () => {
+  let state: logSelection = {
+    address: None,
+    topics: Some([["0xaaa"]]),
+    exclude: {address: Some(["0xbbb"]), topics: None},
+  }
+  let result = BooleanLogicGenerator.generateEnglishDescription(state)
+  assertEqual(result, "Match logs where: topic[0] is 0xaaa AND NOT (the contract address is 0xbbb)")
+})
+
+test("log english description - exclude only", () => {
+  let state: logSelection = {
+    address: None,
+    topics: None,
+    exclude: {address: Some(["0xbbb"]), topics: None},
+  }
+  let result = BooleanLogicGenerator.generateEnglishDescription(state)
+  assertEqual(result, "Match logs where: NOT (the contract address is 0xbbb)")
+})
+
+test("log english description - multi-condition include is parenthesised with exclude", () => {
+  let state: logSelection = {
+    address: Some(["0x1"]),
+    topics: Some([["0x2"]]),
+    exclude: {address: Some(["0x3"]), topics: None},
+  }
+  let result = BooleanLogicGenerator.generateEnglishDescription(state)
+  assertEqual(
+    result,
+    "Match logs where: (the contract address is 0x1 AND topic[0] is 0x2) AND NOT (the contract address is 0x3)",
+  )
+})
+
+test("log english description - empty exclude is ignored", () => {
+  let state: logSelection = {
+    address: Some(["0x1"]),
+    topics: None,
+    exclude: {address: None, topics: None},
+  }
+  let result = BooleanLogicGenerator.generateEnglishDescription(state)
+  assertEqual(result, "Match logs where: the contract address is 0x1")
+})
+
+test("log boolean hierarchy - include with exclude", () => {
+  let state: logSelection = {
+    address: None,
+    topics: Some([["0xaaa"]]),
+    exclude: {address: Some(["0xbbb"]), topics: None},
+  }
+  let result = BooleanLogicGenerator.generateBooleanHierarchy(state)
+  assertEqual(
+    result,
+    "AND\n├── topic[0] = 0xaaa\n└── NOT\n    └── address = 0xbbb",
+  )
+})
+
+test("log boolean hierarchy - exclude only", () => {
+  let state: logSelection = {
+    address: None,
+    topics: None,
+    exclude: {address: Some(["0xbbb"]), topics: None},
+  }
+  let result = BooleanLogicGenerator.generateBooleanHierarchy(state)
+  assertEqual(result, "NOT\n└── address = 0xbbb")
+})
+
+test("log boolean hierarchy - multi-line exclude tree is indented", () => {
+  let state: logSelection = {
+    address: None,
+    topics: None,
+    exclude: {address: Some(["0xbbb"]), topics: Some([["0xccc"]])},
+  }
+  let result = BooleanLogicGenerator.generateBooleanHierarchy(state)
+  assertEqual(
+    result,
+    "NOT\n└── AND\n    ├── address = 0xbbb\n    └── topic[0] = 0xccc",
+  )
+})
+
+test("log isEmptyFilter - exclude-only filter is not empty", () => {
+  let state: logSelection = {
+    address: None,
+    topics: None,
+    exclude: {address: Some(["0xbbb"]), topics: None},
+  }
+  assertEqual(BooleanLogicGenerator.isEmptyFilter(state), false)
+})
+
+test("log isEmptyFilter - filter with empty exclude is empty", () => {
+  let state: logSelection = {
+    address: None,
+    topics: None,
+    exclude: {address: None, topics: None},
+  }
+  assertEqual(BooleanLogicGenerator.isEmptyFilter(state), true)
+})
+
+test("log multi-filter description - filter with exclude", () => {
+  let filters = Some([
+    (
+      {
+        address: None,
+        topics: Some([["0xaaa"]]),
+        exclude: {address: Some(["0xbbb"]), topics: None},
+      }: logSelection
+    ),
+  ])
+  let result = BooleanLogicGenerator.generateMultiFilterDescription(filters)
+  assertEqual(
+    result,
+    "Match logs where: (topic[0] is 0xaaa AND NOT (the contract address is 0xbbb))",
+  )
+})
+
+// Transaction filters
+
+test("transaction english description - include with exclude", () => {
+  let state: transactionSelection = {
+    ...emptyTransactionFields,
+    from_: Some(["0xa"]),
+    exclude: {...emptyTransactionFields, to_: Some(["0xb"])},
+  }
+  let result = TransactionBooleanLogicGenerator.generateEnglishDescription(state)
+  assertEqual(
+    result,
+    "Match transactions where: the sender address is 0xa AND NOT (the recipient address is 0xb)",
+  )
+})
+
+test("transaction boolean hierarchy - exclude only", () => {
+  let state: transactionSelection = {
+    ...emptyTransactionFields,
+    exclude: {...emptyTransactionFields, to_: Some(["0xb"])},
+  }
+  let result = TransactionBooleanLogicGenerator.generateBooleanHierarchy(state)
+  assertEqual(result, "NOT\n└── to = 0xb")
+})
+
+// Block filters
+
+test("block english description - include with exclude", () => {
+  let state: blockSelection = {
+    hash: None,
+    miner: Some(["0xm"]),
+    exclude: {hash: Some(["0xh"]), miner: None},
+  }
+  let result = BlockBooleanLogicGenerator.generateEnglishDescription(state)
+  assertEqual(
+    result,
+    "Match blocks where: the miner address is 0xm AND NOT (the block hash is 0xh)",
+  )
+})
+
+test("block boolean hierarchy - include with exclude", () => {
+  let state: blockSelection = {
+    hash: None,
+    miner: Some(["0xm"]),
+    exclude: {hash: Some(["0xh"]), miner: None},
+  }
+  let result = BlockBooleanLogicGenerator.generateBooleanHierarchy(state)
+  assertEqual(result, "AND\n├── miner = 0xm\n└── NOT\n    └── hash = 0xh")
+})
+
+// Trace filters
+
+test("trace english description - exclude only", () => {
+  let state: traceSelection = {
+    ...emptyTraceFields,
+    exclude: {...emptyTraceFields, callType: Some(["call"])},
+  }
+  let result = TraceBooleanLogicGenerator.generateEnglishDescription(state)
+  assertEqual(result, "Match traces where: NOT (the call type is call)")
+})
+
+// URL round-trip
+
+test("url encode and decode - selections with excludes survive the round trip", () => {
+  let query: query = {
+    fromBlock: 0,
+    toBlock: None,
+    logs: Some([
+      {
+        address: None,
+        topics: Some([["0xaaa"]]),
+        exclude: {address: Some(["0xbbb"]), topics: None},
+      },
+    ]),
+    transactions: Some([
+      {
+        ...emptyTransactionFields,
+        from_: Some(["0xa"]),
+        exclude: {...emptyTransactionFields, to_: Some(["0xb"])},
+      },
+    ]),
+    traces: None,
+    blocks: Some([
+      {
+        hash: None,
+        miner: Some(["0xm"]),
+        exclude: {hash: Some(["0xh"]), miner: None},
+      },
+    ]),
+    includeAllBlocks: None,
+    fieldSelection: {
+      block: [Number],
+      transaction: [Hash],
+      log: [Address],
+      trace: [],
+    },
+    maxNumBlocks: None,
+    maxNumTransactions: None,
+    maxNumLogs: None,
+    maxNumTraces: None,
+    joinMode: None,
+  }
+  let state: UrlEncoder.urlState = {query, selectedChainName: Some("eth")}
+  let encoded = UrlEncoder.encodeUrlStateToUrl(state)
+  switch UrlEncoder.decodeUrlStateFromUrl(encoded) {
+  | Some(decoded) =>
+    assertEqual(UrlEncoder.serializeUrlState(decoded), UrlEncoder.serializeUrlState(state))
+  | None => assertEqual(true, false)
+  }
+})
+
+test("url decode - urls without exclude keys still decode", () => {
+  // Simulates a URL generated before exclude support existed
+  let legacyJson = `{"query":{"fromBlock":0,"toBlock":null,"logs":[{"address":["0x1"],"topics":null}],"transactions":null,"blocks":null,"fieldSelection":{"block":[],"transaction":[],"log":["address"],"trace":[]}},"selectedChainName":"eth"}`
+  switch UrlEncoder.deserializeUrlState(legacyJson) {
+  | Some(decoded) =>
+    switch decoded.query.logs {
+    | Some([log]) => {
+        assertEqual(log.address, Some(["0x1"]))
+        assertEqual(log.exclude, None)
+      }
+    | _ => assertEqual(true, false)
+    }
+  | None => assertEqual(true, false)
+  }
+})

--- a/tests/ExcludeFilters_test.res
+++ b/tests/ExcludeFilters_test.res
@@ -266,3 +266,24 @@ test("url decode - urls without exclude keys still decode", () => {
   | None => assertEqual(true, false)
   }
 })
+
+test("url decode - nested excludes are dropped (single exclude level)", () => {
+  // A hand-crafted URL payload with exclude.exclude: only one level is kept,
+  // matching the server's Selection<T> type
+  let jsonWithNestedExclude = `{"query":{"fromBlock":0,"toBlock":null,"logs":[{"address":null,"topics":[["0xaaa"]],"exclude":{"address":["0xbbb"],"topics":null,"exclude":{"address":["0xccc"],"topics":null}}}],"transactions":null,"blocks":null,"fieldSelection":{"block":[],"transaction":[],"log":["address"],"trace":[]}},"selectedChainName":"eth"}`
+  switch UrlEncoder.deserializeUrlState(jsonWithNestedExclude) {
+  | Some(decoded) =>
+    switch decoded.query.logs {
+    | Some([log]) =>
+      switch log.exclude {
+      | Some(ex) => {
+          assertEqual(ex.address, Some(["0xbbb"]))
+          assertEqual(ex.exclude, None)
+        }
+      | None => assertEqual(true, false)
+      }
+    | _ => assertEqual(true, false)
+    }
+  | None => assertEqual(true, false)
+  }
+})


### PR DESCRIPTION
HyperSync selections support an optional "exclude" filter (same shape as the selection itself; matching rows are dropped from that selection's results). Surface this in the query builder:

- Add an optional recursive `exclude` field to the log, transaction, block, and trace selection types
- Add an "Exclude" editor section to each filter card, reusing the same field inputs as the include section, with a "Transfers (Excl. Mints)" quick example on log filters
- Explain exclusions in the English descriptions ("... AND NOT (...)") and as a NOT branch in the boolean logic hierarchies, both per filter and in the multi-filter Query Logic tab
- Emit "exclude" in the generated query JSON / cURL output and in each filter's Generated Query Structure preview
- Round-trip excludes through shareable URLs (older URLs without the key still decode)
- Fix the test script glob so top-level test files run, and add exclude coverage for descriptions, hierarchies, emptiness checks, and URL round-tripping



Claude-Session: https://claude.ai/code/session_01DUzByXikVZiNwkwJDE8LKj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exclusion filters for logs, transactions, blocks, and traces.
  * Configure exclusions directly in the filter editor with clear active-state indicators.
  * Query structures, shared URLs, and generated requests now preserve exclusion criteria.
  * Boolean logic and plain-English descriptions now show included matches while excluding specified results.
* **Documentation**
  * Documented exclude filters with practical examples.
* **Tests**
  * Added coverage for exclusion behavior, URL round trips, legacy URLs, and empty exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->